### PR TITLE
Schedule daily startup reminder

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,4 @@
-from .calendar_utils import get_today_events
+try:
+    from utils.calendar_utils import get_today_events
+except Exception:  # pragma: no cover - optional import for package init
+    get_today_events = None

--- a/handlers/reminder_handler.py
+++ b/handlers/reminder_handler.py
@@ -526,6 +526,7 @@ def generate_event_hash(event: dict, reminder_type: str) -> str:
 
 __all__ = [
     "schedule_event_reminders", "set_reminder", "unset_reminder", "send_daily_reminder",
+    "startup_daily_reminder",
     "send_event_reminders", "check_birthday_greetings", "schedule_birthday_greetings",
     "create_birthday_greetings_table", "startup_birthday_check",
     "cleanup_old_birthday_greetings", "schedule_cleanup"

--- a/main.py
+++ b/main.py
@@ -48,6 +48,7 @@ from handlers.reminder_handler import (
     send_event_reminders,
     schedule_birthday_greetings,
     create_birthday_greetings_table,
+    startup_daily_reminder,
 )
 from utils.logger import logger
 from database import (
@@ -385,6 +386,7 @@ async def main():
 
     schedule_event_reminders(application.job_queue)
     job_queue = application.job_queue
+    job_queue.run_once(startup_daily_reminder, when=10)
     job_queue.run_repeating(check_and_notify_new_videos, interval=1800, first=10)
 
     create_birthday_greetings_table()

--- a/tests/test_startup_daily_reminder.py
+++ b/tests/test_startup_daily_reminder.py
@@ -1,0 +1,67 @@
+import importlib
+import os
+import sys
+import types
+import datetime
+from unittest.mock import AsyncMock
+import pytest
+
+# Stub external dependencies before importing the module under test
+@pytest.fixture(autouse=True)
+def stub_dependencies(monkeypatch):
+    # telegram stubs
+    tg = types.ModuleType('telegram')
+    tg.ext = types.ModuleType('telegram.ext')
+    tg.constants = types.ModuleType('telegram.constants')
+    tg.helpers = types.ModuleType('telegram.helpers')
+    tg.Update = object
+    tg.ext.JobQueue = object
+    tg.ext.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=object)
+    tg.constants.ParseMode = types.SimpleNamespace(MARKDOWN='markdown', MARKDOWN_V2='markdown_v2')
+    tg.helpers.escape_markdown = lambda text, version=None: text
+    monkeypatch.setitem(sys.modules, 'telegram', tg)
+    monkeypatch.setitem(sys.modules, 'telegram.ext', tg.ext)
+    monkeypatch.setitem(sys.modules, 'telegram.constants', tg.constants)
+    monkeypatch.setitem(sys.modules, 'telegram.helpers', tg.helpers)
+
+    # other stubs
+    monkeypatch.setitem(sys.modules, 'openai', types.SimpleNamespace(api_key=None, OpenAIError=Exception))
+    dotenv_mod = types.ModuleType('dotenv')
+    dotenv_mod.load_dotenv = lambda *a, **kw: None
+    monkeypatch.setitem(sys.modules, 'dotenv', dotenv_mod)
+    pytz_mod = types.ModuleType('pytz')
+    pytz_mod.timezone = lambda name: datetime.timezone.utc
+    monkeypatch.setitem(sys.modules, 'pytz', pytz_mod)
+
+    cal_mod = types.ModuleType('utils.calendar_utils')
+    cal_mod.get_calendar_events = lambda *a, **kw: []
+    cal_mod.get_today_events = lambda *a, **kw: []
+    monkeypatch.setitem(sys.modules, 'utils.calendar_utils', cal_mod)
+
+    # minimal environment variables required by config
+    monkeypatch.setenv('TELEGRAM_TOKEN', 'x')
+    monkeypatch.setenv('GOOGLE_CREDENTIALS', 'x')
+    monkeypatch.setenv('CALENDAR_ID', 'x')
+    monkeypatch.setenv('YOUTUBE_API_KEY', 'x')
+    monkeypatch.setenv('OBERIG_PLAYLIST_ID', 'x')
+
+def test_startup_daily_reminder_triggers(monkeypatch, stub_dependencies):
+    module = importlib.import_module('handlers.reminder_handler')
+    importlib.reload(module)
+
+    monkeypatch.setattr(module, 'get_value', lambda key: None)
+    send_mock = AsyncMock()
+    monkeypatch.setattr(module, 'send_daily_reminder', send_mock)
+
+    class FakeDT(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime.datetime(2024, 1, 1, 10, 0, tzinfo=datetime.timezone.utc)
+
+    monkeypatch.setattr(module, 'datetime', FakeDT)
+
+    context = AsyncMock()
+    import asyncio
+    asyncio.run(module.startup_daily_reminder(context))
+
+    send_mock.assert_awaited_once_with(context)


### PR DESCRIPTION
## Summary
- schedule `startup_daily_reminder` on bot startup
- expose `startup_daily_reminder` in reminder handler exports
- make package import resilient in `__init__.py`
- add regression test for `startup_daily_reminder`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482d502e0c8321beb200996f403e63