### PR TITLE
Fix startup reminder misfire

### DIFF
--- a/main.py
+++ b/main.py
@@ -386,7 +386,11 @@ async def main():
 
     schedule_event_reminders(application.job_queue)
     job_queue = application.job_queue
-    job_queue.run_once(startup_daily_reminder, when=10)
+    job_queue.run_once(
+        startup_daily_reminder,
+        when=10,
+        job_kwargs={"misfire_grace_time": 60},
+    )
     job_queue.run_repeating(check_and_notify_new_videos, interval=1800, first=10)
 
     create_birthday_greetings_table()

--- a/tests/test_startup_daily_reminder.py
+++ b/tests/test_startup_daily_reminder.py
@@ -65,3 +65,8 @@ def test_startup_daily_reminder_triggers(monkeypatch, stub_dependencies):
     asyncio.run(module.startup_daily_reminder(context))
 
     send_mock.assert_awaited_once_with(context)
+
+
+def test_main_schedules_startup_daily_reminder_with_grace(monkeypatch, stub_dependencies):
+    data = open('main.py').read()
+    assert 'misfire_grace_time' in data


### PR DESCRIPTION
## Summary
- allow a short grace period for the startup daily reminder job
- add a test ensuring the code includes misfire_grace_time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483110f8048321998c74a19a82e5dc