### PR TITLE
Consolidate handlers and utils

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,8 +1,8 @@
 import os
 from dotenv import load_dotenv
 
-# Завантажуємо змінні оточення
-load_dotenv(dotenv_path=".env.new")
+# Завантажуємо змінні оточення з .env
+load_dotenv()
 
 # Отримуємо токен бота
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")

--- a/database.py
+++ b/database.py
@@ -268,55 +268,36 @@ def save_event_reminder_hash(event_id: str, reminder_type: str, hash_value: str)
         logger.info(f"✅ Збережено хеш для події {event_id} ({reminder_type})")
     except sqlite3.Error as e:
         logger.error(f"❌ Помилка при збереженні хешу події {event_id}: {e}")
-def add_user_to_list(user_id: str, list_key: str = "bot_users"):
+
+
+def update_user_list(list_key: str, user_id: str, add: bool = True):
+    """Add or remove a user ID from a JSON list stored in the database."""
     try:
         users_str = get_value(list_key)
         users = json.loads(users_str) if users_str else []
         user_id = str(user_id)
-        if user_id not in users:
+        if add and user_id not in users:
             users.append(user_id)
             set_value(list_key, json.dumps(users))
             logger.info(f"✅ Додано користувача {user_id} до списку {list_key}")
-        return users
-    except Exception as e:
-        logger.error(
-            f"❌ Помилка при додаванні користувача {user_id} до списку {list_key}: {e}"
-        )
-        return []
-
-
-def add_user_to_reminders(user_id: str, list_key: str = "users_with_reminders"):
-    try:
-        users_str = get_value(list_key)
-        users = json.loads(users_str) if users_str else []
-        user_id = str(user_id)
-        if user_id not in users:
-            users.append(user_id)
-            set_value(list_key, json.dumps(users))
-            logger.info(f"✅ Додано користувача {user_id} до списку {list_key}")
-        return users
-    except Exception as e:
-        logger.error(
-            f"❌ Помилка при додаванні користувача {user_id} до списку {list_key}: {e}"
-        )
-        return []
-
-
-def remove_user_from_reminders(user_id: str, list_key: str = "users_with_reminders"):
-    try:
-        users_str = get_value(list_key)
-        users = json.loads(users_str) if users_str else []
-        user_id = str(user_id)
-        if user_id in users:
+        elif not add and user_id in users:
             users.remove(user_id)
             set_value(list_key, json.dumps(users))
             logger.info(f"✅ Видалено користувача {user_id} зі списку {list_key}")
         return users
     except Exception as e:
-        logger.error(
-            f"❌ Помилка при видаленні користувача {user_id} зі списку {list_key}: {e}"
-        )
+        logger.error(f"❌ Помилка при оновленні списку {list_key}: {e}")
         return []
+def add_user_to_list(user_id: str, list_key: str = "bot_users"):
+    return update_user_list(list_key, user_id, add=True)
+
+
+def add_user_to_reminders(user_id: str, list_key: str = "users_with_reminders"):
+    return update_user_list(list_key, user_id, add=True)
+
+
+def remove_user_from_reminders(user_id: str, list_key: str = "users_with_reminders"):
+    return update_user_list(list_key, user_id, add=False)
 
 
 def add_group_to_list(chat_id: str, chat_title: str):
@@ -369,6 +350,7 @@ __all__ = [
     "get_value",
     "set_value",
     "delete_value",
+    "update_user_list",
     "add_user_to_list",
     "add_user_to_reminders",
     "remove_user_from_reminders",
@@ -382,6 +364,7 @@ db = type("ReminderDB", (), {
     "get_value": staticmethod(get_value),
     "set_value": staticmethod(set_value),
     "delete_value": staticmethod(delete_value),
+    "update_user_list": staticmethod(update_user_list),
     "add_user_to_reminders": staticmethod(add_user_to_reminders),
     "remove_user_from_reminders": staticmethod(remove_user_from_reminders),
     "save_bot_message": staticmethod(save_bot_message),

--- a/handlers/drive_utils.py
+++ b/handlers/drive_utils.py
@@ -2,7 +2,6 @@ import os
 import asyncio  # Додаємо імпорт для асинхронної затримки
 import io
 import json
-from dotenv import load_dotenv
 from telegram import Update
 from telegram.ext import ContextTypes
 from utils.logger import logger
@@ -18,13 +17,10 @@ from google.oauth2 import service_account
 from telegram import InputFile
 import tempfile  # Для кросплатформної роботи з тимчасовими файлами
 from database import get_value, set_value, save_bot_message
-
-# Завантажуємо змінні оточення
-load_dotenv(dotenv_path=".env.new")
+from config import GOOGLE_CREDENTIALS
 
 # Налаштування Google Drive API
 SCOPES = ["https://www.googleapis.com/auth/drive.readonly"]
-GOOGLE_CREDENTIALS = os.getenv("GOOGLE_CREDENTIALS")
 NOTY_FOLDER_ID = os.getenv(
     "NOTY_FOLDER_ID", "1mLWk6qMDYJ9OtHJPjFA5gI_kTtoUsiIK"
 )  # Використовуємо значення з .env.new або дефолт

--- a/handlers/oberig_assistant_handler.py
+++ b/handlers/oberig_assistant_handler.py
@@ -13,9 +13,10 @@ from utils.calendar_utils import (
 from database import get_value, set_value
 from datetime import datetime
 from handlers.drive_utils import list_sheets, search_sheets, send_sheet
+from utils import init_openai_api
 
 # Налаштування API-ключа OpenAI
-openai.api_key = os.getenv("OPENAI_API_KEY")
+init_openai_api()
 
 # Скорочений системний контекст для зменшення токенів
 OBERIG_SYSTEM_PROMPT = """

--- a/handlers/reminder_handler.py
+++ b/handlers/reminder_handler.py
@@ -5,7 +5,6 @@ from config import TIMEZONE
 from datetime import datetime, timedelta, time
 from database import (
     set_value, get_value, get_cursor,
-    add_user_to_reminders, remove_user_from_reminders,
     save_bot_message, db
 )
 import pytz
@@ -17,7 +16,9 @@ from telegram import Update
 from telegram.constants import ParseMode
 from telegram.helpers import escape_markdown
 
-openai.api_key = os.getenv("OPENAI_API_KEY")
+from utils import init_openai_api
+
+init_openai_api()
 TEST_CHAT_ID = os.getenv("REMINDER_TEST_CHAT_ID")
 berlin_tz = pytz.timezone(TIMEZONE)
 

--- a/handlers/schedule_handler.py
+++ b/handlers/schedule_handler.py
@@ -12,8 +12,6 @@ from utils.logger import logger
 from database import (
     get_value,
     set_value,
-    add_user_to_reminders,
-    remove_user_from_reminders,
 )
 
 # Глобальний словник для кешування ID подій
@@ -233,33 +231,3 @@ async def event_details_callback(update: Update, context: ContextTypes.DEFAULT_T
         )
 
 
-# 🠸 Увімкнення нагадувань
-async def set_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    if not await ensure_private_chat(update, context, "reminder_on"):
-        return
-
-    user_id = str(update.effective_user.id)
-    add_user_to_reminders(user_id)
-
-    await update.message.reply_text(
-        "✅ *Нагадування увімкнено!*\n"
-        "Ви будете отримувати сповіщення про події за годину до їх початку.",
-        parse_mode="Markdown",
-    )
-    logger.info(f"✅ Нагадування увімкнено для користувача {user_id}")
-
-
-# 🠸 Вимкнення нагадувань
-async def unset_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    if not await ensure_private_chat(update, context, "reminder_off"):
-        return
-
-    user_id = str(update.effective_user.id)
-    remove_user_from_reminders(user_id)
-
-    await update.message.reply_text(
-        "🔕 *Нагадування вимкнено*\n"
-        "Ви більше не будете отримувати сповіщення про події за годину до їх початку.",
-        parse_mode="Markdown",
-    )
-    logger.info(f"🔕 Нагадування вимкнено для користувача {user_id}")

--- a/tests/test_notes_search.py
+++ b/tests/test_notes_search.py
@@ -1,0 +1,81 @@
+import importlib
+import types
+import sys
+import asyncio
+import pytest
+
+@pytest.fixture(autouse=True)
+def stub_dependencies(monkeypatch):
+    tg = types.ModuleType('telegram')
+    tg.ext = types.ModuleType('telegram.ext')
+    tg.Update = object
+    tg.ext.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=object)
+    class KB:
+        def __init__(self, *a, **k):
+            pass
+    tg.KeyboardButton = KB
+    tg.ReplyKeyboardMarkup = lambda *a, **kw: None
+    tg.InputFile = object
+    monkeypatch.setitem(sys.modules, 'telegram', tg)
+    monkeypatch.setitem(sys.modules, 'telegram.ext', tg.ext)
+
+    # stub google client libs used by drive_utils
+    ga_flow = types.ModuleType('google_auth_oauthlib.flow')
+    ga_flow.InstalledAppFlow = object
+    monkeypatch.setitem(sys.modules, 'google_auth_oauthlib.flow', ga_flow)
+    ga_req = types.ModuleType('google.auth.transport.requests')
+    ga_req.Request = object
+    monkeypatch.setitem(sys.modules, 'google.auth.transport.requests', ga_req)
+    ga_creds = types.ModuleType('google.oauth2.credentials')
+    ga_creds.Credentials = object
+    monkeypatch.setitem(sys.modules, 'google.oauth2.credentials', ga_creds)
+    sa_mod = types.ModuleType('google.oauth2.service_account')
+    sa_mod.Credentials = types.SimpleNamespace(from_service_account_file=lambda *a, **kw: object())
+    monkeypatch.setitem(sys.modules, 'google.oauth2.service_account', sa_mod)
+
+    google_mod = types.ModuleType('google')
+    oauth2_mod = types.ModuleType('google.oauth2')
+    oauth2_mod.service_account = sa_mod
+    google_mod.oauth2 = oauth2_mod
+    monkeypatch.setitem(sys.modules, 'google', google_mod)
+    monkeypatch.setitem(sys.modules, 'google.oauth2', oauth2_mod)
+    gapi = types.ModuleType('googleapiclient.discovery')
+    gapi.build = lambda *a, **kw: types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, 'googleapiclient.discovery', gapi)
+    errors_mod = types.ModuleType('googleapiclient.errors')
+    errors_mod.HttpError = Exception
+    monkeypatch.setitem(sys.modules, 'googleapiclient.errors', errors_mod)
+    http_mod = types.ModuleType('googleapiclient.http')
+    http_mod.MediaIoBaseDownload = object
+    monkeypatch.setitem(sys.modules, 'googleapiclient.http', http_mod)
+
+    monkeypatch.setitem(sys.modules, 'openai', types.SimpleNamespace(api_key=None))
+    dotenv_mod = types.ModuleType('dotenv')
+    dotenv_mod.load_dotenv = lambda *a, **kw: None
+    monkeypatch.setitem(sys.modules, 'dotenv', dotenv_mod)
+
+    monkeypatch.setenv('TELEGRAM_TOKEN', 'x')
+    monkeypatch.setenv('GOOGLE_CREDENTIALS', 'x')
+    monkeypatch.setenv('CALENDAR_ID', 'x')
+    monkeypatch.setenv('YOUTUBE_API_KEY', 'x')
+    monkeypatch.setenv('OBERIG_PLAYLIST_ID', 'x')
+
+
+def test_search_notes(monkeypatch, stub_dependencies):
+    module = importlib.import_module('handlers.notes_utils')
+    importlib.reload(module)
+
+    async def fake_list(update=None, context=None):
+        return {'all': [{'name': 'Test Note', 'id': '1'}]}
+
+    monkeypatch.setattr(module, 'list_sheets', fake_list)
+
+    class Msg:
+        text = 'test'
+        async def reply_text(self, *a, **kw):
+            return types.SimpleNamespace(message_id=1)
+    update = types.SimpleNamespace(effective_chat=types.SimpleNamespace(id=1, type='private'), message=Msg())
+    context = types.SimpleNamespace(user_data={})
+
+    results = asyncio.run(module.search_notes(update, context, keyword='Test'))
+    assert results and results[0]['id'] == '1'

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,10 @@
+import openai
+import os
+
+
+def init_openai_api():
+    """Set up the OpenAI API key from environment variables."""
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+
+
+__all__ = ["init_openai_api"]

--- a/utils/calendar_utils.py
+++ b/utils/calendar_utils.py
@@ -1,5 +1,6 @@
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
+from utils.youtube_utils import get_youtube_service
 import os
 from datetime import datetime
 import pytz
@@ -254,11 +255,11 @@ def get_latest_youtube_video():
     Отримує посилання на найновше відео за датою публікації з плейліста YouTube.
     """
     try:
-        youtube = build("youtube", "v3", developerKey=YOUTUBE_API_KEY)
+        youtube = get_youtube_service()
 
         request = youtube.playlistItems().list(
             part="snippet",
-            playlistId="PLEkdnztUMQ7-05r94OMzHyCVMCXvkgrFn",
+            playlistId=OBERIG_PLAYLIST_ID,
             maxResults=50,
         )
         response = request.execute()
@@ -307,11 +308,11 @@ def get_most_popular_youtube_video():
     Отримує посилання на найпопулярніше відео з плейліста YouTube.
     """
     try:
-        youtube = build("youtube", "v3", developerKey=YOUTUBE_API_KEY)
+        youtube = get_youtube_service()
 
         request = youtube.playlistItems().list(
             part="snippet",
-            playlistId="PLEkdnztUMQ7-05r94OMzHyCVMCXvkgrFn",
+            playlistId=OBERIG_PLAYLIST_ID,
             maxResults=50,
         )
         response = request.execute()
@@ -364,11 +365,11 @@ def get_top_10_videos():  # Змінюємо назву
     Повертає список кортежів (назва, url, кількість переглядів).
     """
     try:
-        youtube = build("youtube", "v3", developerKey=YOUTUBE_API_KEY)
+        youtube = get_youtube_service()
 
         request = youtube.playlistItems().list(
             part="snippet",
-            playlistId="PLEkdnztUMQ7-05r94OMzHyCVMCXvkgrFn",
+            playlistId=OBERIG_PLAYLIST_ID,
             maxResults=50,
         )
         response = request.execute()
@@ -427,7 +428,7 @@ async def check_new_videos():
         )
         now = datetime.now(BERLIN_TZ)
 
-        youtube = build("youtube", "v3", developerKey=YOUTUBE_API_KEY)
+        youtube = get_youtube_service()
 
         request = youtube.playlistItems().list(
             part="snippet", playlistId=OBERIG_PLAYLIST_ID, maxResults=10

--- a/utils/error_handler.py
+++ b/utils/error_handler.py
@@ -3,6 +3,7 @@
 from telegram import Update
 from telegram.ext import ContextTypes
 from utils.logger import logger
+from config import ADMIN_ID
 
 
 # 🛡️ Глобальний обробник помилок
@@ -28,8 +29,8 @@ async def error_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             show_alert=True,
         )
 
-    # Повідомлення адміністратору (за потреби, додайте ID адміністратора)
-    admin_chat_id = "@LiubomyrK"  # Змініть на актуальний ID адміністратора
+    # Повідомлення адміністратору
+    admin_chat_id = ADMIN_ID
     try:
         await context.bot.send_message(
             chat_id=admin_chat_id,


### PR DESCRIPTION
## Summary
- standardize dotenv loading
- centralize OpenAI API initialization
- remove duplicate reminder handlers
- deduplicate note search logic
- use playlist env variable and shared YouTube client
- add helper `update_user_list`
- use admin ID in error notifications
- add basic note search test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684838ee77648321a227ada2ebf08a9f