### PR TITLE
Fix daily reminder scheduling and event reminders

### DIFF
--- a/tests/test_startup_daily_reminder.py
+++ b/tests/test_startup_daily_reminder.py
@@ -56,7 +56,7 @@ def test_startup_daily_reminder_triggers(monkeypatch, stub_dependencies):
     class FakeDT(datetime.datetime):
         @classmethod
         def now(cls, tz=None):
-            return datetime.datetime(2024, 1, 1, 10, 0, tzinfo=datetime.timezone.utc)
+            return datetime.datetime(2024, 1, 1, 22, 0, tzinfo=datetime.timezone.utc)
 
     monkeypatch.setattr(module, 'datetime', FakeDT)
 


### PR DESCRIPTION
## Summary
- always allow sending daily reminders regardless of time
- trigger startup daily reminder without hour checks
- consider all-day events when sending event reminders
- store reminder hash only after successful send
- run daily reminder every hour instead of only at 9am
- adjust test to verify startup reminder even at 22:00

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497aa6cf3c8321bb27d82c1860c359