### PR TITLE
Fix gitignore typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,4 @@ script_backup.py.py
 *.tmp
 
 # Ігноруємо специфічні артефакти
-tatus
 desktop.ini
-tatus


### PR DESCRIPTION
## Summary
- remove erroneous "tatus" entries from `.gitignore`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68499be8c7bc83219e9c61ebe689def3