### PR TITLE
Refactor utility helpers and schedule menu

### DIFF
--- a/handlers/notes_menu.py
+++ b/handlers/notes_menu.py
@@ -1,0 +1,166 @@
+from telegram import Update, ReplyKeyboardMarkup, KeyboardButton
+from telegram.ext import ContextTypes
+
+from utils.logger import logger
+from .drive_utils import list_sheets, send_sheet
+from database import save_bot_message
+from .user_utils import auto_add_user
+
+
+async def show_notes_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Показує початкове меню нот із клавіатурою."""
+    chat_id = str(update.effective_chat.id)
+    if chat_id != "-1001906486581" and update.effective_chat.type != "private":
+        return
+
+    keyboard = [
+        [KeyboardButton("📋 Всі ноти"), KeyboardButton("🔤 За назвою")],
+        [KeyboardButton("🔍 За ключовим словом"), KeyboardButton("🔙 Головне меню")],
+    ]
+    reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
+
+    if chat_id == "-1001906486581":
+        await context.bot.edit_message_reply_markup(
+            chat_id=chat_id,
+            message_id=update.message.message_id - 1,
+            reply_markup=reply_markup,
+        )
+    else:
+        message = await update.message.reply_text(
+            "🎵 *Обери ноти внизу* ⬇️", parse_mode="Markdown", reply_markup=reply_markup
+        )
+        save_bot_message(chat_id, message.message_id, "general")
+    logger.info("✅ Відображено початкове меню нот")
+
+
+async def show_all_notes(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Показує список усіх нот із клавіатурою."""
+    chat_id = str(update.effective_chat.id)
+    if chat_id != "-1001906486581" and update.effective_chat.type != "private":
+        return
+
+    sheets = await list_sheets(update, context)
+    if not sheets:
+        await update.message.reply_text("❌ *Помилка з нотами 😕* Спробуй пізніше! ⬇️")
+        return
+
+    keyboard = []
+    all_sheets = []
+    for category, items in sheets.items():
+        all_sheets.extend(items)
+    all_sheets.sort(key=lambda x: x["name"].lower())
+
+    for sheet in all_sheets:
+        keyboard.append([KeyboardButton(f"📃 {sheet['name']}")])
+
+    keyboard.append([KeyboardButton("🔙 Меню нот")])
+
+    reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
+
+    if chat_id == "-1001906486581":
+        await context.bot.edit_message_reply_markup(
+            chat_id=chat_id,
+            message_id=update.message.message_id - 1,
+            reply_markup=reply_markup,
+        )
+    else:
+        message = await update.message.reply_text(
+            "🎵 *Вибери ноти внизу* ⬇️", parse_mode="Markdown", reply_markup=reply_markup
+        )
+        save_bot_message(chat_id, message.message_id, "general")
+    logger.info("✅ Відображено список усіх нот")
+
+
+async def show_notes_by_name(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Показує список нот, відсортованих за назвою, із клавіатурою."""
+    chat_id = str(update.effective_chat.id)
+    if chat_id != "-1001906486581" and update.effective_chat.type != "private":
+        return
+
+    sheets = await list_sheets(update, context)
+    if not sheets:
+        await update.message.reply_text("❌ *Помилка з нотами 😕* Спробуй пізніше! ⬇️")
+        return
+
+    keyboard = []
+    all_sheets = []
+    for category, items in sheets.items():
+        all_sheets.extend(items)
+    all_sheets.sort(key=lambda x: x["name"].lower())
+
+    for sheet in all_sheets:
+        keyboard.append([KeyboardButton(f"📃 {sheet['name']}")])
+
+    keyboard.append([KeyboardButton("🔙 Меню нот")])
+
+    reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
+
+    if chat_id == "-1001906486581":
+        await context.bot.edit_message_reply_markup(
+            chat_id=chat_id,
+            message_id=update.message.message_id - 1,
+            reply_markup=reply_markup,
+        )
+    else:
+        message = await update.message.reply_text(
+            "🎵 *Вибери ноти внизу* ⬇️ (за назвою)",
+            parse_mode="Markdown",
+            reply_markup=reply_markup,
+        )
+        save_bot_message(chat_id, message.message_id, "general")
+    logger.info("✅ Відображено список нот, відсортованих за назвою")
+
+
+async def get_sheet_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Обробляє команду /get_sheet для надсилання нот з Google Drive."""
+    await auto_add_user(update, context)
+
+    if not context.args or len(context.args) == 0:
+        await update.message.reply_text(
+            "❌ Вкажіть номер файлу з попереднього списку. Наприклад, /get_sheet 1"
+        )
+        return
+
+    try:
+        file_number = context.args[0].strip(".")
+
+        if not file_number.isdigit():
+            await update.message.reply_text(
+                "❌ Номер файлу має бути цілим числом. Наприклад, /get_sheet 1"
+            )
+            return
+
+        sheets = await list_sheets(update, context)
+        if not sheets:
+            await update.message.reply_text(
+                "❌ *Помилка з нотами 😕* Спробуй пізніше! ⬇️"
+            )
+            return
+
+        all_sheets = []
+        for category, items in sheets.items():
+            all_sheets.extend(items)
+
+        index = int(file_number) - 1
+        if index < 0 or index >= len(all_sheets):
+            await update.message.reply_text(
+                f"❌ Номер файлу має бути від 1 до {len(all_sheets)}"
+            )
+            return
+
+        sheet = all_sheets[index]
+        await send_sheet(update, context, sheet["id"])
+
+    except Exception as e:
+        logger.error(f"Помилка при отриманні нот: {e}")
+        await update.message.reply_text(
+            "❌ Виникла несподівана помилка. Спробуйте пізніше. #Оберіг 😔"
+        )
+
+
+__all__ = [
+    "show_notes_menu",
+    "show_all_notes",
+    "show_notes_by_name",
+    "get_sheet_command",
+]

--- a/handlers/schedule_menu.py
+++ b/handlers/schedule_menu.py
@@ -1,0 +1,68 @@
+from telegram import Update, ReplyKeyboardMarkup, KeyboardButton
+from telegram.ext import ContextTypes
+from utils.logger import logger
+from database import get_value, save_bot_message
+from .user_utils import auto_add_user
+import json
+
+SCHEDULE_MENU_TEXT_PRIVATE = """📅 *Меню розкладу*
+
+Виберіть одну з опцій:
+📋 - Переглянути розклад подій
+🕒 - Переглянути події на сьогодні
+
+🔔 Нагадування (за замовчуванням увімкнені):
+- 🔕 Вимкнути нагадування - припинити отримувати сповіщення за годину до події
+- 🔔 Увімкнути нагадування - відновити сповіщення за годину до події"""
+
+SCHEDULE_MENU_TEXT_GROUP = """📅 *Меню розкладу*
+
+Виберіть одну з опцій:
+📋 - Переглянути розклад подій
+🕒 - Переглянути події на сьогодні
+
+🔔 Нагадування завжди увімкнені для групових чатів і не можуть бути вимкнені."""
+
+
+async def show_schedule_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await auto_add_user(update, context)
+    logger.info("🔄 Спроба відобразити меню розкладу")
+    try:
+        if update.effective_chat.type == "private":
+            users_with_reminders_str = get_value("users_with_reminders")
+            users_with_reminders = json.loads(users_with_reminders_str) if users_with_reminders_str else []
+            user_id = str(update.effective_user.id)
+            if user_id in users_with_reminders:
+                reminder_button = KeyboardButton("🔕 Вимкнути нагадування")
+            else:
+                reminder_button = KeyboardButton("🔔 Увімкнути нагадування")
+
+            keyboard = [
+                [KeyboardButton("📋 Розклад подій")],
+                [KeyboardButton("🕒 Події на сьогодні")],
+                [reminder_button],
+                [KeyboardButton("🔙 Головне меню")],
+            ]
+            menu_text = SCHEDULE_MENU_TEXT_PRIVATE
+        else:
+            keyboard = [
+                [KeyboardButton("📋 Розклад подій")],
+                [KeyboardButton("🕒 Події на сьогодні")],
+                [KeyboardButton("🔙 Головне меню")],
+            ]
+            menu_text = SCHEDULE_MENU_TEXT_GROUP
+        reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
+        message = await update.message.reply_text(
+            menu_text, parse_mode="Markdown", reply_markup=reply_markup
+        )
+        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
+        logger.info("✅ Відображено меню розкладу")
+    except Exception as e:
+        logger.error(f"❌ Помилка при відображенні меню розкладу: {e}")
+        message = await update.message.reply_text(
+            "❌ *Щось пішло не так 😔* Спробуй ще раз! ⬇️"
+        )
+        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
+
+
+__all__ = ["show_schedule_menu"]

--- a/handlers/start_handler.py
+++ b/handlers/start_handler.py
@@ -10,11 +10,6 @@ from telegram import (
 )
 from telegram.ext import ContextTypes
 from utils.logger import logger
-from utils.calendar_utils import (
-    get_latest_youtube_video,
-    get_most_popular_youtube_video,
-    get_top_10_videos,
-)
 from database import (
     set_value,
     get_value,
@@ -40,40 +35,18 @@ from handlers.feedback_handler import start_feedback, show_my_feedback
 from handlers.oberig_assistant_handler import handle_oberig_assistant
 from handlers.drive_utils import (
     list_sheets,
-    search_sheets,
     send_sheet,
 )
 from handlers.notes_utils import search_notes
-
-SCHEDULE_MENU_TEXT_PRIVATE = """📅 *Меню розкладу*
-
-Виберіть одну з опцій:
-📋 - Переглянути розклад подій
-🕒 - Переглянути події на сьогодні
-
-🔔 Нагадування (за замовчуванням увімкнені):
-- 🔕 Вимкнути нагадування - припинити отримувати сповіщення за годину до події
-- 🔔 Увімкнути нагадування - відновити сповіщення за годину до події"""
-
-SCHEDULE_MENU_TEXT_GROUP = """📅 *Меню розкладу*
-
-Виберіть одну з опцій:
-📋 - Переглянути розклад подій
-🕒 - Переглянути події на сьогодні
-
-🔔 Нагадування завжди увімкнені для групових чатів і не можуть бути вимкнені."""
-
-YOUTUBE_MENU_TEXT = """🎥 *Меню YouTube*
-
-Виберіть одну з опцій:
-📺 - Переглянути всі відео
-🆕 - Переглянути найновіше відео
-🔥 - Переглянути найпопулярніше відео
-🏆 - Топ-10 найпопулярніших відео
-
-🔔 Керування сповіщеннями:
-- 🔔 Увімкнути сповіщення - отримувати повідомлення про нові відео
-- 🔕 Вимкнути сповіщення - припинити отримувати повідомлення"""
+from .notes_menu import show_notes_menu, show_all_notes, show_notes_by_name
+from .youtube_menu import (
+    show_youtube_menu,
+    latest_video_command,
+    most_popular_video_command,
+    top_10_videos_command,
+)
+from .schedule_menu import show_schedule_menu
+from .user_utils import auto_add_user
 
 MAIN_MENU_TEXT = """
 🎶 *Головне меню OBERIG*  
@@ -196,34 +169,6 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
         save_bot_message(chat_id, message.message_id, "general")
 
 
-async def latest_video_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    await auto_add_user(update, context)
-    logger.info("🔄 Виконання команди: /latest_video")
-    try:
-        video_url = get_latest_youtube_video()
-        if video_url:
-            message = await update.message.reply_text(
-                f"🆕 *Найновіше відео хору OBERIG:*\n\n"
-                f"👆 [Переглянути відео]({video_url})\n\n"
-                "📤 Поділитися цим відео: `/share_latest`",
-                parse_mode="Markdown",
-            )
-            save_bot_message(
-                str(update.effective_chat.id), message.message_id, "general"
-            )
-            logger.info("✅ Команда /latest_video виконана успішно.")
-        else:
-            message = await update.message.reply_text(ERROR_VIDEO_NOT_FOUND)
-            save_bot_message(
-                str(update.effective_chat.id), message.message_id, "general"
-            )
-            logger.warning(ERROR_VIDEO_NOT_FOUND)
-    except Exception as e:
-        logger.error(f"❌ Помилка у виконанні команди /latest_video: {e}")
-        message = await update.message.reply_text(ERROR_GENERAL)
-        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
-
-
 async def feedback_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await auto_add_user(update, context)
     keyboard = [
@@ -249,120 +194,6 @@ async def redirect_to_private(update: Update, context: ContextTypes.DEFAULT_TYPE
     )
     save_bot_message(chat_id, message.message_id, "general")
     logger.info("✅ Користувач перенаправлений у приватний чат")
-
-
-async def show_notes_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Показує початкове меню нот із клавіатурою."""
-    chat_id = str(update.effective_chat.id)
-    if chat_id != "-1001906486581" and update.effective_chat.type != "private":
-        return
-
-    keyboard = [
-        [KeyboardButton("📋 Всі ноти"), KeyboardButton("🔤 За назвою")],
-        [KeyboardButton("🔍 За ключовим словом"), KeyboardButton("🔙 Головне меню")],
-    ]
-    reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
-
-    if chat_id == "-1001906486581":
-        await context.bot.edit_message_reply_markup(
-            chat_id=chat_id,
-            message_id=update.message.message_id - 1,
-            reply_markup=reply_markup,
-        )
-    else:
-        message = await update.message.reply_text(
-            "🎵 *Обери ноти внизу* ⬇️", parse_mode="Markdown", reply_markup=reply_markup
-        )
-        save_bot_message(chat_id, message.message_id, "general")
-    logger.info("✅ Відображено початкове меню нот")
-
-
-async def show_all_notes(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Показує список усіх нот із клавіатурою."""
-    chat_id = str(update.effective_chat.id)
-    if chat_id != "-1001906486581" and update.effective_chat.type != "private":
-        return
-
-    # Отримуємо список нот
-    sheets = await list_sheets(update, context)
-    if not sheets:
-        await update.message.reply_text("❌ *Помилка з нотами 😕* Спробуй пізніше! ⬇️")
-        return
-
-    # Створюємо клавіатуру з нотами
-    keyboard = []
-    all_sheets = []
-    for category, items in sheets.items():
-        all_sheets.extend(items)
-    all_sheets.sort(key=lambda x: x["name"].lower())  # Сортуємо за назвою
-
-    # Додаємо кнопки для кожної ноти
-    for sheet in all_sheets:
-        keyboard.append([KeyboardButton(f"📃 {sheet['name']}")])
-
-    # Додаємо кнопку "Повернутися до меню нот"
-    keyboard.append([KeyboardButton("🔙 Меню нот")])
-
-    reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
-
-    if chat_id == "-1001906486581":
-        await context.bot.edit_message_reply_markup(
-            chat_id=chat_id,
-            message_id=update.message.message_id - 1,
-            reply_markup=reply_markup,
-        )
-    else:
-        message = await update.message.reply_text(
-            "🎵 *Вибери ноти внизу* ⬇️", parse_mode="Markdown", reply_markup=reply_markup
-        )
-        save_bot_message(chat_id, message.message_id, "general")
-    logger.info("✅ Відображено список усіх нот")
-
-
-async def show_notes_by_name(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Показує список нот, відсортованих за назвою, із клавіатурою."""
-    chat_id = str(update.effective_chat.id)
-    if chat_id != "-1001906486581" and update.effective_chat.type != "private":
-        return
-
-    # Отримуємо список нот
-    sheets = await list_sheets(update, context)
-    if not sheets:
-        await update.message.reply_text("❌ *Помилка з нотами 😕* Спробуй пізніше! ⬇️")
-        return
-
-    # Створюємо клавіатуру з нотами, відсортованими за назвою
-    keyboard = []
-    all_sheets = []
-    for category, items in sheets.items():
-        all_sheets.extend(items)
-    all_sheets.sort(key=lambda x: x["name"].lower())  # Сортуємо за назвою
-
-    # Додаємо кнопки для кожної ноти
-    for sheet in all_sheets:
-        keyboard.append([KeyboardButton(f"📃 {sheet['name']}")])
-
-    # Додаємо кнопку "Повернутися до меню нот"
-    keyboard.append([KeyboardButton("🔙 Меню нот")])
-
-    reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
-
-    if chat_id == "-1001906486581":
-        await context.bot.edit_message_reply_markup(
-            chat_id=chat_id,
-            message_id=update.message.message_id - 1,
-            reply_markup=reply_markup,
-        )
-    else:
-        message = await update.message.reply_text(
-            "🎵 *Вибери ноти внизу* ⬇️ (за назвою)",
-            parse_mode="Markdown",
-            reply_markup=reply_markup,
-        )
-        save_bot_message(chat_id, message.message_id, "general")
-    logger.info("✅ Відображено список нот, відсортованих за назвою")
-
-
 
 
 async def text_menu_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -608,189 +439,6 @@ async def text_menu_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         save_bot_message(chat_id, message.message_id, "general")
 
 
-async def top_10_videos_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    await auto_add_user(update, context)
-    logger.info("Виконання команди: /top_10_videos")
-    try:
-        videos = get_top_10_videos()
-        if not videos:
-            message = await update.message.reply_text(
-                "⚠️ *Відео не знайдено 😔* Спробуй пізніше! ⬇️"
-            )
-            save_bot_message(
-                str(update.effective_chat.id), message.message_id, "general"
-            )
-            logger.warning("Відео не знайдено")
-            return
-
-        # Отримуємо поточну сторінку з user_data (за замовчуванням 0)
-        page = context.user_data.get("top_10_page", 0)
-        videos_per_page = 5
-        total_pages = (len(videos) + videos_per_page - 1) // videos_per_page
-
-        # Перевіряємо межі сторінки
-        if page < 0:
-            page = 0
-        elif page >= total_pages:
-            page = total_pages - 1
-        context.user_data["top_10_page"] = page
-
-        # Отримуємо відео для поточної сторінки
-        start_idx = page * videos_per_page
-        end_idx = min(start_idx + videos_per_page, len(videos))
-        current_videos = videos[start_idx:end_idx]
-
-        # Формуємо текст повідомлення
-        message_text = "*🏆 Топ-10 найпопулярніших відео:*\n\n"
-        for i, (title, url, views) in enumerate(current_videos, start_idx + 1):
-            title = title[:120] + "..." if len(title) > 120 else title  # Збільшуємо до 120 символів
-            message_text += f"**{i}.** [{title}]({url})\n👁 {views:,} переглядів\n\n"
-
-        # Додаємо інформацію про сторінку
-        message_text += f"\n📄 Сторінка {page + 1} з {total_pages}"
-
-        # Додаємо кнопки пагінації
-        keyboard = []
-        if page > 0:
-            keyboard.append(InlineKeyboardButton("⬅️ Попередня п'ятірка", callback_data="top_10_prev"))
-        if page < total_pages - 1:
-            keyboard.append(InlineKeyboardButton("Наступна п'ятірка ➡️", callback_data="top_10_next"))
-        reply_markup = InlineKeyboardMarkup([keyboard]) if keyboard else None
-
-        # Надсилаємо або оновлюємо повідомлення
-        if update.callback_query:
-            await update.callback_query.edit_message_text(
-                message_text,
-                parse_mode="Markdown",
-                disable_web_page_preview=True,
-                reply_markup=reply_markup,
-            )
-        else:
-            message = await update.message.reply_text(
-                message_text,
-                parse_mode="Markdown",
-                disable_web_page_preview=True,
-                reply_markup=reply_markup,
-            )
-            save_bot_message(
-                str(update.effective_chat.id), message.message_id, "general"
-            )
-
-        logger.info(f"Команда /top_10_videos виконана успішно (Сторінка {page + 1})")
-    except Exception as e:
-        logger.error(f"Помилка у виконанні команди /top_10_videos: {e}")
-        message = await update.message.reply_text(
-            "❌ *Щось пішло не так 😔* Спробуй ще раз! ⬇️"
-        )
-        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
-
-
-async def show_youtube_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    await auto_add_user(update, context)
-    logger.info("Спроба відобразити меню YouTube")
-    try:
-        keyboard = [
-            [KeyboardButton("📺 Наші відео")],
-            [KeyboardButton("🆕 Найновше відео")],
-            [KeyboardButton("🔥 Найпопулярніше відео")],
-            [KeyboardButton("🏆 Топ-10 відео")],
-            [
-                KeyboardButton("🔔 Увімкнути сповіщення"),
-                KeyboardButton("🔕 Вимкнути сповіщення"),
-            ],
-            [KeyboardButton("🔙 Головне меню")],
-        ]
-        reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
-        message = await update.message.reply_text(
-            YOUTUBE_MENU_TEXT,
-            parse_mode="Markdown",
-            reply_markup=reply_markup,
-        )
-        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
-        logger.info("Відображено меню YouTube")
-    except Exception as e:
-        logger.error(f"Помилка при відображенні меню YouTube: {e}")
-        message = await update.message.reply_text(
-            "❌ *Щось пішло не так 😔* Спробуй ще раз! ⬇️"
-        )
-        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
-
-
-async def most_popular_video_command(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-):
-    await auto_add_user(update, context)
-    logger.info("🔄 Виконання команди: /most_popular_video")
-    try:
-        video_url = get_most_popular_youtube_video()
-        if video_url:
-            message = await update.message.reply_text(
-                f"🔥 *Найпопулярніше відео хору OBERIG:*\n\n"
-                f"👆 [Переглянути відео]({video_url})\n\n"
-                "📤 Поділитися цим відео: `/share_popular`",
-                parse_mode="Markdown",
-            )
-            save_bot_message(
-                str(update.effective_chat.id), message.message_id, "general"
-            )
-            logger.info("✅ Команда /most_popular_video виконана успішно")
-        else:
-            message = await update.message.reply_text(
-                "⚠️ *Відео не знайдено 😔* Спробуй пізніше! ⬇️"
-            )
-            save_bot_message(
-                str(update.effective_chat.id), message.message_id, "general"
-            )
-            logger.warning("Відео не знайдено")
-    except Exception as e:
-        logger.error(f"❌ Помилка у виконанні команди /most_popular_video: {e}")
-        message = await update.message.reply_text(
-            "❌ *Щось пішло не так 😔* Спробуй ще раз! ⬇️"
-        )
-        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
-
-
-async def show_schedule_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    await auto_add_user(update, context)
-    logger.info("🔄 Спроба відобразити меню розкладу")
-    try:
-        if update.effective_chat.type == "private":
-            users_with_reminders_str = get_value("users_with_reminders")
-            users_with_reminders = (
-                json.loads(users_with_reminders_str) if users_with_reminders_str else []
-            )
-            user_id = str(update.effective_user.id)
-            if user_id in users_with_reminders:
-                reminder_button = KeyboardButton("🔕 Вимкнути нагадування")
-            else:
-                reminder_button = KeyboardButton("🔔 Увімкнути нагадування")
-
-            keyboard = [
-                [KeyboardButton("📋 Розклад подій")],
-                [KeyboardButton("🕒 Події на сьогодні")],
-                [reminder_button],
-                [KeyboardButton("🔙 Головне меню")],
-            ]
-            menu_text = SCHEDULE_MENU_TEXT_PRIVATE
-        else:
-            keyboard = [
-                [KeyboardButton("📋 Розклад подій")],
-                [KeyboardButton("🕒 Події на сьогодні")],
-                [KeyboardButton("🔙 Головне меню")],
-            ]
-            menu_text = SCHEDULE_MENU_TEXT_GROUP
-        reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
-        message = await update.message.reply_text(
-            menu_text, parse_mode="Markdown", reply_markup=reply_markup
-        )
-        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
-        logger.info("✅ Відображено меню розкладу")
-    except Exception as e:
-        logger.error(f"❌ Помилка при відображенні меню розкладу: {e}")
-        message = await update.message.reply_text(
-            "❌ *Щось пішло не так 😔* Спробуй ще раз! ⬇️"
-        )
-        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
 
 
 async def get_main_keyboard(user_id: int) -> ReplyKeyboardMarkup:
@@ -833,50 +481,6 @@ async def button_click(update: Update, context: ContextTypes.DEFAULT_TYPE):
         logger.warning(f"⚠️ Невідома callback команда: {data}")
 
 
-async def auto_add_user(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    try:
-        user_id = str(update.effective_user.id)
-        chat_type = update.effective_chat.type
-        bot_users_str = get_value("bot_users")
-        bot_users = json.loads(bot_users_str) if bot_users_str else []
-        bot_users_info_str = get_value("bot_users_info")
-        bot_users_info = json.loads(bot_users_info_str) if bot_users_info_str else {}
-
-        # Додаємо користувача до bot_users і bot_users_info лише якщо його ще немає
-        if user_id not in bot_users:
-            bot_users.append(user_id)
-            bot_users_info[user_id] = (
-                update.effective_user.first_name
-                or update.effective_user.username
-                or "Невідомо"
-            )
-            set_value("bot_users", json.dumps(bot_users))
-            set_value("bot_users_info", json.dumps(bot_users_info))
-            logger.info(f"✅ Додано нового користувача {user_id} до списку bot_users")
-
-        # Додаємо до нагадувань лише для приватних чатів і лише якщо користувача ще немає в users_with_reminders
-        if chat_type == "private":
-            users_with_reminders_str = get_value("users_with_reminders")
-            users_with_reminders = (
-                json.loads(users_with_reminders_str) if users_with_reminders_str else []
-            )
-            if user_id not in users_with_reminders:
-                users_with_reminders.append(user_id)
-                set_value("users_with_reminders", json.dumps(users_with_reminders))
-                logger.info(
-                    f"✅ Автоматично додано користувача {user_id} до нагадувань"
-                )
-
-        # Додаємо групу, якщо це груповий чат
-        if chat_type in ["group", "supergroup"]:
-            add_group_to_list(
-                str(update.effective_chat.id),
-                update.effective_chat.title or "Невідома група",
-            )
-
-        logger.info(f"✅ Користувач {user_id} оброблений при взаємодії")
-    except Exception as e:
-        logger.error(f"❌ Помилка при автоматичному додаванні користувача: {e}")
 
 
 async def show_main_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -927,77 +531,13 @@ async def show_group_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
         save_bot_message(str(update.effective_chat.id), message.message_id, "general")
 
 
-async def get_sheet_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """
-    Обробляє команду /get_sheet для надсилання нот з Google Drive.
-    """
-    await auto_add_user(update, context)
-
-    # Перевіряємо, чи передано номер файлу
-    if not context.args or len(context.args) == 0:
-        await update.message.reply_text(
-            "❌ Вкажіть номер файлу з попереднього списку. Наприклад, /get_sheet 1"
-        )
-        return
-
-    try:
-        # Отримуємо номер файлу
-        file_number = context.args[0].strip(".")
-
-        # Перевіряємо, чи є число
-        if not file_number.isdigit():
-            await update.message.reply_text(
-                "❌ Номер файлу має бути цілим числом. Наприклад, /get_sheet 1"
-            )
-            return
-
-        # Отримуємо список нот
-        sheets = await list_sheets(update, context)
-        if not sheets:
-            await update.message.reply_text(
-                "❌ *Помилка з нотами 😕* Спробуй пізніше! ⬇️"
-            )
-            return
-
-        # Збираємо всі ноти в один список
-        all_sheets = []
-        for category, items in sheets.items():
-            all_sheets.extend(items)
-
-        # Перевіряємо діапазон номера
-        index = int(file_number) - 1
-        if index < 0 or index >= len(all_sheets):
-            await update.message.reply_text(
-                f"❌ Номер файлу має бути від 1 до {len(all_sheets)}"
-            )
-            return
-
-        # Надсилаємо ноту
-        sheet = all_sheets[index]
-        await send_sheet(update, context, sheet["id"])
-
-    except Exception as e:
-        logger.error(f"Помилка при отриманні нот: {e}")
-        await update.message.reply_text(
-            "❌ Виникла несподівана помилка. Спробуйте пізніше. #Оберіг 😔"
-        )
-
 
 __all__ = [
     "start",
     "show_main_menu",
     "show_group_menu",
-    "latest_video_command",
     "feedback_command",
     "text_menu_handler",
-    "show_youtube_menu",
-    "most_popular_video_command",
-    "top_10_videos_command",
     "button_click",
-    "auto_add_user",
     "redirect_to_private",
-    "show_notes_menu",
-    "show_all_notes",
-    "show_notes_by_name",
-    "get_sheet_command",
 ]

--- a/handlers/user_utils.py
+++ b/handlers/user_utils.py
@@ -1,0 +1,57 @@
+from telegram import Update
+from telegram.ext import ContextTypes
+from utils.logger import logger
+from database import (
+    get_value,
+    set_value,
+    add_group_to_list,
+)
+import json
+
+
+async def auto_add_user(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Ensure user and group are tracked and reminders enabled."""
+    try:
+        user_id = str(update.effective_user.id)
+        chat_type = update.effective_chat.type
+        bot_users_str = get_value("bot_users")
+        bot_users = json.loads(bot_users_str) if bot_users_str else []
+        bot_users_info_str = get_value("bot_users_info")
+        bot_users_info = json.loads(bot_users_info_str) if bot_users_info_str else {}
+
+        # Add user if not already stored
+        if user_id not in bot_users:
+            bot_users.append(user_id)
+            bot_users_info[user_id] = (
+                update.effective_user.first_name
+                or update.effective_user.username
+                or "Невідомо"
+            )
+            set_value("bot_users", json.dumps(bot_users))
+            set_value("bot_users_info", json.dumps(bot_users_info))
+            logger.info(f"✅ Додано нового користувача {user_id} до списку bot_users")
+
+        # Automatically enable reminders for private chats
+        if chat_type == "private":
+            users_with_reminders_str = get_value("users_with_reminders")
+            users_with_reminders = (
+                json.loads(users_with_reminders_str) if users_with_reminders_str else []
+            )
+            if user_id not in users_with_reminders:
+                users_with_reminders.append(user_id)
+                set_value("users_with_reminders", json.dumps(users_with_reminders))
+                logger.info(f"✅ Автоматично додано користувача {user_id} до нагадувань")
+
+        # Register groups
+        if chat_type in ["group", "supergroup"]:
+            add_group_to_list(
+                str(update.effective_chat.id),
+                update.effective_chat.title or "Невідома група",
+            )
+
+        logger.info(f"✅ Користувач {user_id} оброблений при взаємодії")
+    except Exception as e:
+        logger.error(f"❌ Помилка при автоматичному додаванні користувача: {e}")
+
+
+__all__ = ["auto_add_user"]

--- a/handlers/youtube_menu.py
+++ b/handlers/youtube_menu.py
@@ -1,0 +1,195 @@
+from telegram import (
+    Update,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    ReplyKeyboardMarkup,
+    KeyboardButton,
+)
+from telegram.ext import ContextTypes
+
+from utils.calendar_utils import (
+    get_latest_youtube_video,
+    get_most_popular_youtube_video,
+    get_top_10_videos,
+)
+from database import save_bot_message
+from utils.logger import logger
+from .user_utils import auto_add_user
+
+YOUTUBE_MENU_TEXT = """🎥 *Меню YouTube*
+
+Виберіть одну з опцій:
+📺 - Переглянути всі відео
+🆕 - Переглянути найновіше відео
+🔥 - Переглянути найпопулярніше відео
+🏆 - Топ-10 найпопулярніших відео
+
+🔔 Керування сповіщеннями:
+- 🔔 Увімкнути сповіщення - отримувати повідомлення про нові відео
+- 🔕 Вимкнути сповіщення - припинити отримувати повідомлення"""
+
+ERROR_VIDEO_NOT_FOUND = "⚠️ *Відео не знайдено 😔* Спробуй пізніше! ⬇️"
+ERROR_GENERAL = "❌ *Щось пішло не так 😔* Спробуй ще раз! ⬇️"
+
+
+async def latest_video_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await auto_add_user(update, context)
+    logger.info("🔄 Виконання команди: /latest_video")
+    try:
+        video_url = get_latest_youtube_video()
+        if video_url:
+            message = await update.message.reply_text(
+                f"🆕 *Найновіше відео хору OBERIG:*\n\n"
+                f"👆 [Переглянути відео]({video_url})\n\n"
+                "📤 Поділитися цим відео: `/share_latest`",
+                parse_mode="Markdown",
+            )
+            save_bot_message(
+                str(update.effective_chat.id), message.message_id, "general"
+            )
+            logger.info("✅ Команда /latest_video виконана успішно.")
+        else:
+            message = await update.message.reply_text(ERROR_VIDEO_NOT_FOUND)
+            save_bot_message(
+                str(update.effective_chat.id), message.message_id, "general"
+            )
+            logger.warning(ERROR_VIDEO_NOT_FOUND)
+    except Exception as e:
+        logger.error(f"❌ Помилка у виконанні команди /latest_video: {e}")
+        message = await update.message.reply_text(ERROR_GENERAL)
+        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
+
+
+async def top_10_videos_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await auto_add_user(update, context)
+    logger.info("Виконання команди: /top_10_videos")
+    try:
+        videos = get_top_10_videos()
+        if not videos:
+            message = await update.message.reply_text(
+                ERROR_VIDEO_NOT_FOUND
+            )
+            save_bot_message(
+                str(update.effective_chat.id), message.message_id, "general"
+            )
+            logger.warning("Відео не знайдено")
+            return
+
+        page = context.user_data.get("top_10_page", 0)
+        videos_per_page = 5
+        total_pages = (len(videos) + videos_per_page - 1) // videos_per_page
+
+        if page < 0:
+            page = 0
+        elif page >= total_pages:
+            page = total_pages - 1
+        context.user_data["top_10_page"] = page
+
+        start_idx = page * videos_per_page
+        end_idx = min(start_idx + videos_per_page, len(videos))
+        current_videos = videos[start_idx:end_idx]
+
+        message_text = "*🏆 Топ-10 найпопулярніших відео:*\n\n"
+        for i, (title, url, views) in enumerate(current_videos, start_idx + 1):
+            title = title[:120] + "..." if len(title) > 120 else title
+            message_text += f"**{i}.** [{title}]({url})\n👁 {views:,} переглядів\n\n"
+
+        message_text += f"\n📄 Сторінка {page + 1} з {total_pages}"
+
+        keyboard = []
+        if page > 0:
+            keyboard.append(InlineKeyboardButton("⬅️ Попередня п'ятірка", callback_data="top_10_prev"))
+        if page < total_pages - 1:
+            keyboard.append(InlineKeyboardButton("Наступна п'ятірка ➡️", callback_data="top_10_next"))
+        reply_markup = InlineKeyboardMarkup([keyboard]) if keyboard else None
+
+        if update.callback_query:
+            await update.callback_query.edit_message_text(
+                message_text,
+                parse_mode="Markdown",
+                disable_web_page_preview=True,
+                reply_markup=reply_markup,
+            )
+        else:
+            message = await update.message.reply_text(
+                message_text,
+                parse_mode="Markdown",
+                disable_web_page_preview=True,
+                reply_markup=reply_markup,
+            )
+            save_bot_message(
+                str(update.effective_chat.id), message.message_id, "general"
+            )
+
+        logger.info(f"Команда /top_10_videos виконана успішно (Сторінка {page + 1})")
+    except Exception as e:
+        logger.error(f"Помилка у виконанні команди /top_10_videos: {e}")
+        message = await update.message.reply_text(ERROR_GENERAL)
+        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
+
+
+async def show_youtube_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await auto_add_user(update, context)
+    logger.info("Спроба відобразити меню YouTube")
+    try:
+        keyboard = [
+            [KeyboardButton("📺 Наші відео")],
+            [KeyboardButton("🆕 Найновше відео")],
+            [KeyboardButton("🔥 Найпопулярніше відео")],
+            [KeyboardButton("🏆 Топ-10 відео")],
+            [
+                KeyboardButton("🔔 Увімкнути сповіщення"),
+                KeyboardButton("🔕 Вимкнути сповіщення"),
+            ],
+            [KeyboardButton("🔙 Головне меню")],
+        ]
+        reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
+        message = await update.message.reply_text(
+            YOUTUBE_MENU_TEXT,
+            parse_mode="Markdown",
+            reply_markup=reply_markup,
+        )
+        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
+        logger.info("Відображено меню YouTube")
+    except Exception as e:
+        logger.error(f"Помилка при відображенні меню YouTube: {e}")
+        message = await update.message.reply_text(ERROR_GENERAL)
+        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
+
+
+async def most_popular_video_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await auto_add_user(update, context)
+    logger.info("🔄 Виконання команди: /most_popular_video")
+    try:
+        video_url = get_most_popular_youtube_video()
+        if video_url:
+            message = await update.message.reply_text(
+                f"🔥 *Найпопулярніше відео хору OBERIG:*\n\n"
+                f"👆 [Переглянути відео]({video_url})\n\n"
+                "📤 Поділитися цим відео: `/share_popular`",
+                parse_mode="Markdown",
+            )
+            save_bot_message(
+                str(update.effective_chat.id), message.message_id, "general"
+            )
+            logger.info("✅ Команда /most_popular_video виконана успішно")
+        else:
+            message = await update.message.reply_text(
+                ERROR_VIDEO_NOT_FOUND
+            )
+            save_bot_message(
+                str(update.effective_chat.id), message.message_id, "general"
+            )
+            logger.warning("Відео не знайдено")
+    except Exception as e:
+        logger.error(f"❌ Помилка у виконанні команди /most_popular_video: {e}")
+        message = await update.message.reply_text(ERROR_GENERAL)
+        save_bot_message(str(update.effective_chat.id), message.message_id, "general")
+
+
+__all__ = [
+    "latest_video_command",
+    "show_youtube_menu",
+    "most_popular_video_command",
+    "top_10_videos_command",
+]

--- a/main.py
+++ b/main.py
@@ -21,17 +21,17 @@ from handlers.start_handler import (
     start,
     show_main_menu,
     show_group_menu,
-    latest_video_command,
     feedback_command,
     text_menu_handler,
+    button_click,
+)
+from handlers.youtube_menu import (
+    latest_video_command,
     show_youtube_menu,
     most_popular_video_command,
-    top_10_videos_command,  # Оновлюємо
-    button_click,
-    auto_add_user,
-    redirect_to_private,
-    show_notes_menu,
+    top_10_videos_command,
 )
+from handlers.notes_menu import show_notes_menu
 from handlers.help_handler import help_command
 from handlers.schedule_handler import (
     schedule_command,


### PR DESCRIPTION
## Summary
- extract auto_add_user into `handlers/user_utils.py`
- move schedule menu logic to new `handlers/schedule_menu.py`
- import menu handlers directly in `start_handler`
- drop unused imports in `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499cb0b2408321940fd95928ebd930