### PR TITLE
Fix notification settings defaults

### DIFF
--- a/database.py
+++ b/database.py
@@ -107,8 +107,8 @@ def init_db():
         default_values = {
             "bot_users": ["611511159"],
             "users_with_reminders": ["611511159", "1564008807"],
-            "video_notifications_disabled": [],
-            "group_notifications_disabled": [],
+            "video_notifications_disabled": {},
+            "group_notifications_disabled": {},
             "group_chats": [],
             "sent_reminders": {"2025-02-14": []},
             "daily_reminder_sent": False,

--- a/handlers/notification_handler.py
+++ b/handlers/notification_handler.py
@@ -28,17 +28,20 @@ async def check_and_notify_new_videos(context: ContextTypes.DEFAULT_TYPE):
 
         # Отримуємо статус сповіщень для користувачів і груп
         video_notifications_disabled_str = get_value("video_notifications_disabled")
-        video_notifications_disabled = (
-            json.loads(video_notifications_disabled_str)
-            if video_notifications_disabled_str
-            else {}
-        )
+        if video_notifications_disabled_str:
+            video_notifications_disabled = json.loads(video_notifications_disabled_str)
+            if not isinstance(video_notifications_disabled, dict):
+                video_notifications_disabled = {}
+        else:
+            video_notifications_disabled = {}
+
         group_notifications_disabled_str = get_value("group_notifications_disabled")
-        group_notifications_disabled = (
-            json.loads(group_notifications_disabled_str)
-            if group_notifications_disabled_str
-            else {}
-        )
+        if group_notifications_disabled_str:
+            group_notifications_disabled = json.loads(group_notifications_disabled_str)
+            if not isinstance(group_notifications_disabled, dict):
+                group_notifications_disabled = {}
+        else:
+            group_notifications_disabled = {}
 
         for video in new_videos:
             video_id = video["video_id"]
@@ -141,11 +144,12 @@ async def toggle_video_notifications(
     """
     user_id = str(update.effective_user.id)
     video_notifications_disabled_str = get_value("video_notifications_disabled")
-    video_notifications_disabled = (
-        json.loads(video_notifications_disabled_str)
-        if video_notifications_disabled_str
-        else {}
-    )
+    if video_notifications_disabled_str:
+        video_notifications_disabled = json.loads(video_notifications_disabled_str)
+        if not isinstance(video_notifications_disabled, dict):
+            video_notifications_disabled = {}
+    else:
+        video_notifications_disabled = {}
 
     video_notifications_disabled[user_id] = not enable
     set_value("video_notifications_disabled", json.dumps(video_notifications_disabled))

--- a/main.py
+++ b/main.py
@@ -174,7 +174,7 @@ async def main():
 
     group_notifications = get_value("group_notifications_disabled")
     if group_notifications is None:
-        set_value("group_notifications_disabled", json.dumps(False))
+        set_value("group_notifications_disabled", json.dumps({}))
 
     group_chats = get_value("group_chats")
     if group_chats is None:
@@ -208,7 +208,7 @@ async def main():
 
     video_notifications = get_value("video_notifications_disabled")
     if video_notifications is None:
-        set_value("video_notifications_disabled", json.dumps(False))
+        set_value("video_notifications_disabled", json.dumps({}))
 
     application = ApplicationBuilder().token(TELEGRAM_TOKEN).build()
 


### PR DESCRIPTION
## Summary
- switch default notification settings from list to dict
- setup empty dicts at first bot start
- ensure dictionaries when toggling notifications

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849bdd689ec8321b0e2f1294025584d