### PR TITLE
Refactor note handling, add pagination

### DIFF
--- a/handlers/notes_menu.py
+++ b/handlers/notes_menu.py
@@ -10,7 +10,7 @@ from .user_utils import auto_add_user
 async def show_notes_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Показує початкове меню нот із клавіатурою."""
     chat_id = str(update.effective_chat.id)
-    if chat_id != "-1001906486581" and update.effective_chat.type != "private":
+    if update.effective_chat.type != "private":
         return
 
     keyboard = [
@@ -19,24 +19,19 @@ async def show_notes_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     ]
     reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
 
-    if chat_id == "-1001906486581":
-        await context.bot.edit_message_reply_markup(
-            chat_id=chat_id,
-            message_id=update.message.message_id - 1,
-            reply_markup=reply_markup,
-        )
-    else:
-        message = await update.message.reply_text(
-            "🎵 *Обери ноти внизу* ⬇️", parse_mode="Markdown", reply_markup=reply_markup
-        )
-        save_bot_message(chat_id, message.message_id, "general")
+    message = await update.message.reply_text(
+        "🎵 *Обери ноти внизу* ⬇️",
+        parse_mode="Markdown",
+        reply_markup=reply_markup,
+    )
+    save_bot_message(chat_id, message.message_id, "general")
     logger.info("✅ Відображено початкове меню нот")
 
 
 async def show_all_notes(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Показує список усіх нот із клавіатурою."""
     chat_id = str(update.effective_chat.id)
-    if chat_id != "-1001906486581" and update.effective_chat.type != "private":
+    if update.effective_chat.type != "private":
         return
 
     sheets = await list_sheets(update, context)
@@ -57,58 +52,18 @@ async def show_all_notes(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
 
-    if chat_id == "-1001906486581":
-        await context.bot.edit_message_reply_markup(
-            chat_id=chat_id,
-            message_id=update.message.message_id - 1,
-            reply_markup=reply_markup,
-        )
-    else:
-        message = await update.message.reply_text(
-            "🎵 *Вибери ноти внизу* ⬇️", parse_mode="Markdown", reply_markup=reply_markup
-        )
-        save_bot_message(chat_id, message.message_id, "general")
+    message = await update.message.reply_text(
+        "🎵 *Вибери ноти внизу* ⬇️",
+        parse_mode="Markdown",
+        reply_markup=reply_markup,
+    )
+    save_bot_message(chat_id, message.message_id, "general")
     logger.info("✅ Відображено список усіх нот")
 
 
 async def show_notes_by_name(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Показує список нот, відсортованих за назвою, із клавіатурою."""
-    chat_id = str(update.effective_chat.id)
-    if chat_id != "-1001906486581" and update.effective_chat.type != "private":
-        return
-
-    sheets = await list_sheets(update, context)
-    if not sheets:
-        await update.message.reply_text("❌ *Помилка з нотами 😕* Спробуй пізніше! ⬇️")
-        return
-
-    keyboard = []
-    all_sheets = []
-    for category, items in sheets.items():
-        all_sheets.extend(items)
-    all_sheets.sort(key=lambda x: x["name"].lower())
-
-    for sheet in all_sheets:
-        keyboard.append([KeyboardButton(f"📃 {sheet['name']}")])
-
-    keyboard.append([KeyboardButton("🔙 Меню нот")])
-
-    reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
-
-    if chat_id == "-1001906486581":
-        await context.bot.edit_message_reply_markup(
-            chat_id=chat_id,
-            message_id=update.message.message_id - 1,
-            reply_markup=reply_markup,
-        )
-    else:
-        message = await update.message.reply_text(
-            "🎵 *Вибери ноти внизу* ⬇️ (за назвою)",
-            parse_mode="Markdown",
-            reply_markup=reply_markup,
-        )
-        save_bot_message(chat_id, message.message_id, "general")
-    logger.info("✅ Відображено список нот, відсортованих за назвою")
+    """Застаріла функція, що викликає ``show_all_notes``."""
+    await show_all_notes(update, context)
 
 
 async def get_sheet_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -161,6 +116,5 @@ async def get_sheet_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 __all__ = [
     "show_notes_menu",
     "show_all_notes",
-    "show_notes_by_name",
     "get_sheet_command",
 ]

--- a/handlers/notes_utils.py
+++ b/handlers/notes_utils.py
@@ -1,19 +1,23 @@
 from telegram import Update, ReplyKeyboardMarkup, KeyboardButton
 from telegram.ext import ContextTypes
 from utils.logger import logger
-from handlers.drive_utils import list_sheets, send_sheet
+from handlers.drive_utils import list_sheets
 from database import get_value, save_bot_message
+import json
 
 
 async def search_notes(
-    update: Update, context: ContextTypes.DEFAULT_TYPE, keyword: str = None
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    keyword: str | None = None,
+    next_page: bool = False,
 ):
-    """Обробляє пошук нот за ключовим словом і показує клавіатуру з результатами."""
+    """Пошук нот за ключовим словом з підтримкою пагінації (5 елементів на сторінку)."""
     chat_id = str(update.effective_chat.id)
-    if chat_id != "-1001906486581" and update.effective_chat.type != "private":
+    if update.effective_chat.type != "private":
         return []
 
-    # Якщо ключове слово не вказане, повертаємо порожній список або використовуємо текст повідомлення
+    # Якщо ключове слово не вказане, намагаємося взяти його з тексту повідомлення
     if not keyword and update.message and update.message.text:
         keyword = update.message.text.lower()
     elif not keyword:
@@ -37,45 +41,53 @@ async def search_notes(
                 )
             return []
 
-    # Гнучкий пошук нот за ключовим словом (з урахуванням фрагментів слів і повного тексту)
-    results = []
-    all_sheets = []
-    for category, items in sheets.items():
+    # Пошук нот за ключовим словом
+    all_sheets: list[dict] = []
+    for items in sheets.values():
         all_sheets.extend(items)
-    for sheet in all_sheets:
-        name_lower = sheet["name"].lower()
-        if keyword in name_lower or any(  # Пошук у повному тексті назви
-            keyword in part.lower() for part in name_lower.split()
-        ):  # Пошук у фрагментах слів
-            results.append(sheet)
+    results = [s for s in all_sheets if keyword in s["name"].lower()]
 
-    if results and update:  # Повертаємо результати лише якщо є оновлення (update)
-        # Сортуємо результати за алфавітом для зручності
-        results.sort(key=lambda x: x["name"].lower())
-        keyboard = []
-        for sheet in results[
-            :5
-        ]:  # Обмежуємо до 5 результатів, щоб уникнути переповнення
-            keyboard.append([KeyboardButton(f"📃 {sheet['name']}")])
+    if not results:
+        if update:
+            message = await update.message.reply_text(
+                f"🔍 *Ноти за '{keyword}' не знайдено 😔* Спробуй інше слово! ⬇️",
+                parse_mode="Markdown",
+            )
+            save_bot_message(chat_id, message.message_id, "general")
+        logger.info(f"🔍 Нот за ключовим словом '{keyword}' не знайдено")
+        return []
+
+    # Сортуємо результати за алфавітом
+    results.sort(key=lambda x: x["name"].lower())
+
+    # Якщо це новий пошук або змінене ключове слово, зберігаємо його
+    if not next_page or context.user_data.get("last_search_keyword") != keyword:
+        context.user_data["last_search_keyword"] = keyword
+        context.user_data["search_results"] = results
+        context.user_data["search_offset"] = 0
+
+    stored = context.user_data.get("search_results", [])
+    offset = context.user_data.get("search_offset", 0)
+    page = stored[offset : offset + 5]
+    context.user_data["search_offset"] = offset + len(page)
+
+    if update:
+        keyboard = [[KeyboardButton(f"📃 {sheet['name']}")] for sheet in page]
+        if context.user_data["search_offset"] < len(stored):
+            keyboard.append([KeyboardButton("➡️ Ще результати")])
         keyboard.append([KeyboardButton("🔙 Меню нот")])
         reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
         message = await update.message.reply_text(
-            "🎵 *Обери ноти внизу* ⬇️", parse_mode="Markdown", reply_markup=reply_markup
+            "🎵 *Обери ноти внизу* ⬇️",
+            parse_mode="Markdown",
+            reply_markup=reply_markup,
         )
         save_bot_message(chat_id, message.message_id, "general")
         logger.info(
-            f"✅ Пошук за ключовим словом '{keyword}' виконано з результатами: {len(results)} нот знайдено"
+            f"✅ Пошук за ключовим словом '{keyword}' повернув {len(stored)} результатів"
         )
-        return results
-    elif not results and update:
-        message = await update.message.reply_text(
-            f"🔍 *Ноти за '{keyword}' не знайдено 😔* Спробуй інше слово! ⬇️",
-            parse_mode="Markdown",
-        )
-        save_bot_message(chat_id, message.message_id, "general")
-        logger.info(f"🔍 Нот за ключовим словом '{keyword}' не знайдено")
-        return []
-    return results
+
+    return page
 
 
 __all__ = ["search_notes"]

--- a/handlers/oberig_assistant_handler.py
+++ b/handlers/oberig_assistant_handler.py
@@ -12,7 +12,8 @@ from utils.calendar_utils import (
 )
 from database import get_value, set_value
 from datetime import datetime
-from handlers.drive_utils import list_sheets, search_sheets, send_sheet
+from handlers.drive_utils import list_sheets, send_sheet
+from handlers.notes_utils import search_notes
 from utils import init_openai_api
 
 # Налаштування API-ключа OpenAI
@@ -78,7 +79,7 @@ async def search_drive_files(
     """
     try:
         # Виклик існуючої функції пошуку нот
-        await search_sheets(update, context, query)
+        await search_notes(update, context, keyword=query)
     except Exception as e:
         logger.error(f"Помилка пошуку файлів: {e}")
         await update.message.reply_text(

--- a/handlers/start_handler.py
+++ b/handlers/start_handler.py
@@ -39,7 +39,7 @@ from handlers.drive_utils import (
 )
 from handlers.notes_utils import search_notes
 
-from .notes_menu import show_notes_menu, show_all_notes, show_notes_by_name
+from .notes_menu import show_notes_menu, show_all_notes
 from .youtube_menu import (
     show_youtube_menu,
     latest_video_command,
@@ -135,16 +135,6 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
             )
             save_bot_message(chat_id, message.message_id, "general")
             logger.info("✅ Команда /start виконана успішно у приватному чаті.")
-        elif chat_id == "-1001906486581":
-            keyboard = [[KeyboardButton("Помічник"), KeyboardButton("🎵 Ноти")]]
-            reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
-            message = await update.message.reply_text(
-                "🎵 *Обери ноти внизу* ⬇️",
-                parse_mode="Markdown",
-                reply_markup=reply_markup,
-            )
-            save_bot_message(chat_id, message.message_id, "general")
-            logger.info("✅ Відображено початкове меню в групі -1001906486581")
         else:
             try:
                 all_chats = get_value("group_chats")
@@ -220,13 +210,13 @@ async def redirect_to_private(update: Update, context: ContextTypes.DEFAULT_TYPE
 async def text_menu_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await auto_add_user(update, context)
     chat_id = str(update.effective_chat.id)
-    from .notes_menu import show_notes_menu, show_all_notes, show_notes_by_name
+    from .notes_menu import show_notes_menu, show_all_notes
     from .youtube_menu import show_youtube_menu, latest_video_command, most_popular_video_command, top_10_videos_command
     chat_type = update.effective_chat.type
     text = update.message.text
     logger.info(f"🔄 Обробка текстової кнопки або повідомлення: {text}")
 
-    if chat_type != "private" and chat_id != "-1001906486581":
+    if chat_type != "private":
         if text == "Помічник":
             await redirect_to_private(update, context)
         return
@@ -368,17 +358,6 @@ async def text_menu_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             elif text == "🔙 Головне меню":
                 if chat_type == "private":
                     await show_main_menu(update, context)
-                elif chat_id == "-1001906486581":
-                    keyboard = [[KeyboardButton("Помічник"), KeyboardButton("🎵 Ноти")]]
-                    reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
-                    await context.bot.edit_message_reply_markup(
-                        chat_id=chat_id,
-                        message_id=update.message.message_id - 1,
-                        reply_markup=reply_markup,
-                    )
-                    logger.info(
-                        "✅ Оновлено клавіатуру до головного меню в групі -1001906486581"
-                    )
             elif text == "🗑️ Видалити повідомлення":
                 if await is_admin(update.effective_user.id):
                     await delete_messages(update, context)
@@ -411,43 +390,39 @@ async def text_menu_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     )
                     save_bot_message(chat_id, message.message_id, "general")
                     logger.info("✅ Натиснуто кнопку '📈 Статистика використання'")
-            elif text == "Помічник" and chat_id == "-1001906486581":
+            elif text == "Помічник":
                 await redirect_to_private(update, context)
-                logger.info("✅ Натиснуто кнопку 'Помічник' у групі -1001906486581")
-            elif text == "🎵 Ноти" and (
-                chat_type == "private" or chat_id == "-1001906486581"
-            ):
+                logger.info("✅ Натиснуто кнопку 'Помічник' у групі")
+            elif text == "🎵 Ноти" and chat_type == "private":
                 await show_notes_menu(update, context)
                 logger.info("✅ Натиснуто кнопку '🎵 Ноти'")
-            elif text == "📋 Всі ноти" and (
-                chat_type == "private" or chat_id == "-1001906486581"
-            ):
+            elif text == "📋 Всі ноти" and chat_type == "private":
                 await show_all_notes(update, context)
                 logger.info("✅ Натиснуто кнопку '📋 Всі ноти'")
-            elif text == "🔤 За назвою" and (
-                chat_type == "private" or chat_id == "-1001906486581"
-            ):
-                await show_notes_by_name(update, context)
+            elif text == "🔤 За назвою" and chat_type == "private":
+                await show_all_notes(update, context)
                 logger.info("✅ Натиснуто кнопку '🔤 За назвою'")
-            elif text == "🔍 За ключовим словом" and (
-                chat_type == "private" or chat_id == "-1001906486581"
-            ):
+            elif text == "🔍 За ключовим словом" and chat_type == "private":
                 message = await update.message.reply_text(
                     "🔍 *Введи слово для пошуку нот* ⬇️", parse_mode="Markdown"
                 )
                 save_bot_message(chat_id, message.message_id, "general")
                 context.user_data["awaiting_keyword"] = True
                 logger.info("✅ Натиснуто кнопку '🔍 За ключовим словом'")
-            elif text == "🔙 Меню нот" and (
-                chat_type == "private" or chat_id == "-1001906486581"
-            ):
+            elif text == "➡️ Ще результати" and chat_type == "private":
+                await search_notes(
+                    update,
+                    context,
+                    keyword=context.user_data.get("last_search_keyword"),
+                    next_page=True,
+                )
+                logger.info("✅ Показано наступні результати пошуку нот")
+            elif text == "🔙 Меню нот" and chat_type == "private":
                 await show_notes_menu(update, context)
                 logger.info("✅ Повернення до меню нот")
 
         # Обробка лише тексту, який не пов’язаний із нотами або стандартними командами
-        elif context.user_data.get("awaiting_keyword") and (
-            chat_type == "private" or chat_id == "-1001906486581"
-        ):
+        elif context.user_data.get("awaiting_keyword") and chat_type == "private":
             # Передаємо текст як ключове слово для пошуку нот
             await search_notes(update, context)
             logger.info(f"✅ Виконується пошук нот за ключовим словом: {text}")
@@ -530,7 +505,7 @@ async def button_click(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if data == "redirect_private":
         await redirect_to_private(update, context)
-        logger.info("✅ Натиснуто кнопку 'Помічник' у групі -1001906486581")
+        logger.info("✅ Натиснуто кнопку 'Помічник' у групі")
     elif data == "top_10_prev":
         # Переходимо на попередню сторінку
         context.user_data["top_10_page"] = context.user_data.get("top_10_page", 0) - 1

--- a/main.py
+++ b/main.py
@@ -234,16 +234,7 @@ async def main():
         BotCommand("delete_recent", "Видалити за 30 хв (адмін)"),
     ]
 
-    group_commands = [
-        BotCommand(
-            "start", "Запустити бота"
-        )  # Лише одна команда для всіх груп, окрім -1001906486581
-    ]
-
-    special_group_commands = [
-        BotCommand("start", "Запустити бота"),
-        BotCommand("notes", "Меню нот"),  # Додаткові команди для -1001906486581
-    ]
+    group_commands = [BotCommand("start", "Запустити бота")]
 
     admin_commands = [
         BotCommand("start", "Запустити бота"),
@@ -280,13 +271,6 @@ async def main():
             commands=group_commands, scope=BotCommandScopeAllGroupChats()
         )
         logger.info("Встановлено команди для всіх групових чатів (лише /start)")
-        await application.bot.set_my_commands(
-            commands=special_group_commands,
-            scope=BotCommandScopeChat(chat_id=-1001906486581),
-        )
-        logger.info(
-            "Встановлено команди для спеціального групового чату -1001906486581"
-        )
         if admin_id:
             await application.bot.set_my_commands(
                 commands=admin_commands,
@@ -362,9 +346,6 @@ async def main():
             "delete_recent", delete_recent, filters=filters.ChatType.PRIVATE
         ),
         MessageHandler(filters.TEXT & filters.ChatType.PRIVATE, text_menu_handler),
-        MessageHandler(
-            filters.TEXT & filters.Chat(chat_id=-1001906486581), text_menu_handler
-        ),
     ]
 
     for handler in handlers:


### PR DESCRIPTION
## Summary
- fix missing `json` import and remove unused import
- ensure listing notes uses cached results
- consolidate note menu handlers and restrict note features to private chats
- add paginated note search with "More results" option
- remove hardcoded group logic and special command setup
- simplify assistant search interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510a95b2dc8321b2ace3aac3da824d