### PR TITLE
Add Assistants API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@
    - `YOUTUBE_API_KEY` – ключ API YouTube
    - `OBERIG_PLAYLIST_ID` – ID плейліста хору
    - `ADMIN_CHAT_ID` – ID адміністратора
+   - `OPENAI_API_KEY` – ключ для доступу до OpenAI
+   - `OPENAI_ASSISTANT_ID` – ID створеного асистента (необов'язково)
    - `TIMEZONE` – часовий пояс (необовʼязково, за замовчуванням `Europe/Berlin`)
+   
+   Бот зчитує ці значення з файла `.env` при запуску.
 3. Встановіть залежності:
 
 ```bash

--- a/handlers/oberig_assistant_handler.py
+++ b/handlers/oberig_assistant_handler.py
@@ -19,10 +19,15 @@ from database import get_value, set_value
 from datetime import datetime
 from handlers.drive_utils import list_sheets, send_sheet
 from handlers.notes_utils import search_notes
-from utils import init_openai_api, call_openai_chat
+from utils import (
+    init_openai_api,
+    call_openai_chat,
+    call_openai_assistant,
+    get_openai_assistant_id,
+)
 
 # Налаштування API-ключа OpenAI
-init_openai_api()
+ASSISTANT_ID = init_openai_api()
 
 # Скорочений системний контекст для зменшення токенів
 OBERIG_SYSTEM_PROMPT = """
@@ -306,12 +311,17 @@ async def handle_oberig_assistant(update: Update, context: ContextTypes.DEFAULT_
         )  # Зменшено до 3 повідомлень для економії токенів
         messages.append({"role": "user", "content": user_message})
 
-        # Запит до ChatGPT з мінімальними токенами для відповіді
-        bot_response = await call_openai_chat(
-            messages=messages,
-            max_tokens=200,
-            temperature=0.9,
-        )
+        # Запит до ChatGPT або асистента з мінімальними токенами для відповіді
+        if ASSISTANT_ID:
+            bot_response = await call_openai_assistant(
+                messages=messages, assistant_id=ASSISTANT_ID
+            )
+        else:
+            bot_response = await call_openai_chat(
+                messages=messages,
+                max_tokens=200,
+                temperature=0.9,
+            )
         # Додаємо емоджі, хештеги, смайли та прикраси
         bot_response = (
             f"🎵 {bot_response} 😊 #Оберіг ✨\n🌟 Хочеш дізнатися більше? 🙂 #Хор"

--- a/handlers/reminder_handler.py
+++ b/handlers/reminder_handler.py
@@ -17,9 +17,14 @@ from telegram import Update
 from telegram.constants import ParseMode
 from telegram.helpers import escape_markdown
 
-from utils import init_openai_api, call_openai_chat
+from utils import (
+    init_openai_api,
+    call_openai_chat,
+    call_openai_assistant,
+    get_openai_assistant_id,
+)
 
-init_openai_api()
+ASSISTANT_ID = init_openai_api()
 TEST_CHAT_ID = os.getenv("REMINDER_TEST_CHAT_ID")
 berlin_tz = pytz.timezone(TIMEZONE)
 
@@ -374,11 +379,17 @@ async def generate_birthday_greeting(name: str, time_of_day: str) -> str:
             "morning – енергійний, evening – теплий. Завершуй текст крапкою або знаком оклику."
         )
 
-        greeting = await call_openai_chat(
-            messages=[{"role": "user", "content": prompt}],
-            max_tokens=150,
-            temperature=0.9,
-        )
+        if ASSISTANT_ID:
+            greeting = await call_openai_assistant(
+                messages=[{"role": "user", "content": prompt}],
+                assistant_id=ASSISTANT_ID,
+            )
+        else:
+            greeting = await call_openai_chat(
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=150,
+                temperature=0.9,
+            )
 
         if greeting and greeting[-1] not in [".", "!", "?" ]:
             greeting += "!"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv==1.0.1
 nest_asyncio==1.5.8
 pymorphy3==2.0.1
 pymorphy3-dicts-uk==2.4.1
+openai>=1.0

--- a/tests/test_birthday_greetings.py
+++ b/tests/test_birthday_greetings.py
@@ -29,7 +29,36 @@ def stub_dependencies(monkeypatch):
     openai_mod = types.ModuleType('openai')
     openai_mod.api_key = None
     openai_mod.OpenAIError = Exception
-    openai_mod.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=lambda **kw: types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg)])))
+    openai_mod.chat = types.SimpleNamespace(
+        completions=types.SimpleNamespace(
+            create=lambda **kw: types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=msg)]
+            )
+        )
+    )
+    openai_mod.beta = types.SimpleNamespace(
+        threads=types.SimpleNamespace(
+            create=lambda: types.SimpleNamespace(id='t'),
+            messages=types.SimpleNamespace(
+                create=lambda **kw: None,
+                list=lambda **kw: types.SimpleNamespace(
+                    data=[
+                        types.SimpleNamespace(
+                            content=[
+                                types.SimpleNamespace(
+                                    text=types.SimpleNamespace(value='Вітаємо!')
+                                )
+                            ]
+                        )
+                    ]
+                ),
+            ),
+            runs=types.SimpleNamespace(
+                create=lambda **kw: types.SimpleNamespace(id='r', status='queued'),
+                retrieve=lambda **kw: types.SimpleNamespace(id='r', status='completed'),
+            ),
+        )
+    )
     monkeypatch.setitem(sys.modules, 'openai', openai_mod)
 
     # other libs
@@ -51,6 +80,8 @@ def stub_dependencies(monkeypatch):
     async def fake_call(*a, **kw):
         return 'Вітаємо!'
     utils_mod.call_openai_chat = fake_call
+    utils_mod.call_openai_assistant = fake_call
+    utils_mod.get_openai_assistant_id = lambda: None
     monkeypatch.setitem(sys.modules, 'utils', utils_mod)
 
     # in-memory database

--- a/tests/test_calendar_features.py
+++ b/tests/test_calendar_features.py
@@ -16,6 +16,19 @@ def stub_dependencies(monkeypatch, tmp_path):
     openai_mod = types.ModuleType('openai')
     openai_mod.api_key = None
     openai_mod.OpenAIError = Exception
+    openai_mod.beta = types.SimpleNamespace(
+        threads=types.SimpleNamespace(
+            create=lambda: types.SimpleNamespace(id='t'),
+            messages=types.SimpleNamespace(
+                create=lambda **kw: None,
+                list=lambda **kw: types.SimpleNamespace(data=[]),
+            ),
+            runs=types.SimpleNamespace(
+                create=lambda **kw: types.SimpleNamespace(id='r', status='queued'),
+                retrieve=lambda **kw: types.SimpleNamespace(id='r', status='completed'),
+            ),
+        )
+    )
     monkeypatch.setitem(sys.modules, 'openai', openai_mod)
 
     dotenv_mod = types.ModuleType('dotenv')

--- a/tests/test_notes_search.py
+++ b/tests/test_notes_search.py
@@ -49,7 +49,21 @@ def stub_dependencies(monkeypatch):
     http_mod.MediaIoBaseDownload = object
     monkeypatch.setitem(sys.modules, 'googleapiclient.http', http_mod)
 
-    monkeypatch.setitem(sys.modules, 'openai', types.SimpleNamespace(api_key=None))
+    openai_mod = types.SimpleNamespace(api_key=None)
+    openai_mod.beta = types.SimpleNamespace(
+        threads=types.SimpleNamespace(
+            create=lambda: types.SimpleNamespace(id='t'),
+            messages=types.SimpleNamespace(
+                create=lambda **kw: None,
+                list=lambda **kw: types.SimpleNamespace(data=[]),
+            ),
+            runs=types.SimpleNamespace(
+                create=lambda **kw: types.SimpleNamespace(id='r', status='queued'),
+                retrieve=lambda **kw: types.SimpleNamespace(id='r', status='completed'),
+            ),
+        )
+    )
+    monkeypatch.setitem(sys.modules, 'openai', openai_mod)
     dotenv_mod = types.ModuleType('dotenv')
     dotenv_mod.load_dotenv = lambda *a, **kw: None
     monkeypatch.setitem(sys.modules, 'dotenv', dotenv_mod)

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -1,0 +1,58 @@
+import importlib
+import types
+import sys
+import asyncio
+
+import pytest
+
+@pytest.fixture(autouse=True)
+def stub_openai(monkeypatch):
+    msg = types.SimpleNamespace(content='hi')
+    openai_mod = types.ModuleType('openai')
+    openai_mod.api_key = None
+    openai_mod.OpenAIError = Exception
+    openai_mod.chat = types.SimpleNamespace(
+        completions=types.SimpleNamespace(
+            create=lambda **kw: types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=msg)]
+            )
+        )
+    )
+    openai_mod.beta = types.SimpleNamespace(
+        threads=types.SimpleNamespace(
+            create=lambda: types.SimpleNamespace(id='t'),
+            messages=types.SimpleNamespace(
+                create=lambda **kw: None,
+                list=lambda **kw: types.SimpleNamespace(
+                    data=[
+                        types.SimpleNamespace(
+                            content=[types.SimpleNamespace(text=types.SimpleNamespace(value='hi'))]
+                        )
+                    ]
+                ),
+            ),
+            runs=types.SimpleNamespace(
+                create=lambda **kw: types.SimpleNamespace(id='r'),
+                retrieve=lambda **kw: types.SimpleNamespace(id='r', status='completed'),
+            ),
+        )
+    )
+    monkeypatch.setitem(sys.modules, 'openai', openai_mod)
+
+
+def test_call_openai_chat(stub_openai):
+    utils = importlib.import_module('utils')
+    importlib.reload(utils)
+    result = asyncio.run(utils.call_openai_chat([{'role': 'user', 'content': 'hi'}]))
+    assert result == 'hi'
+
+
+def test_call_openai_assistant(stub_openai):
+    utils = importlib.import_module('utils')
+    importlib.reload(utils)
+    result = asyncio.run(
+        utils.call_openai_assistant([
+            {'role': 'user', 'content': 'hi'}
+        ], assistant_id='asst')
+    )
+    assert result == 'hi'

--- a/tests/test_past_events.py
+++ b/tests/test_past_events.py
@@ -22,6 +22,19 @@ def stub_dependencies(monkeypatch, tmp_path):
     openai_mod = types.ModuleType('openai')
     openai_mod.api_key = None
     openai_mod.OpenAIError = Exception
+    openai_mod.beta = types.SimpleNamespace(
+        threads=types.SimpleNamespace(
+            create=lambda: types.SimpleNamespace(id='t'),
+            messages=types.SimpleNamespace(
+                create=lambda **kw: None,
+                list=lambda **kw: types.SimpleNamespace(data=[]),
+            ),
+            runs=types.SimpleNamespace(
+                create=lambda **kw: types.SimpleNamespace(id='r', status='queued'),
+                retrieve=lambda **kw: types.SimpleNamespace(id='r', status='completed'),
+            ),
+        )
+    )
     monkeypatch.setitem(sys.modules, 'openai', openai_mod)
 
     dotenv_mod = types.ModuleType('dotenv')

--- a/tests/test_startup_daily_reminder.py
+++ b/tests/test_startup_daily_reminder.py
@@ -25,7 +25,21 @@ def stub_dependencies(monkeypatch):
     monkeypatch.setitem(sys.modules, 'telegram.helpers', tg.helpers)
 
     # other stubs
-    monkeypatch.setitem(sys.modules, 'openai', types.SimpleNamespace(api_key=None, OpenAIError=Exception))
+    openai_mod = types.SimpleNamespace(api_key=None, OpenAIError=Exception)
+    openai_mod.beta = types.SimpleNamespace(
+        threads=types.SimpleNamespace(
+            create=lambda: types.SimpleNamespace(id='t'),
+            messages=types.SimpleNamespace(
+                create=lambda **kw: None,
+                list=lambda **kw: types.SimpleNamespace(data=[]),
+            ),
+            runs=types.SimpleNamespace(
+                create=lambda **kw: types.SimpleNamespace(id='r', status='queued'),
+                retrieve=lambda **kw: types.SimpleNamespace(id='r', status='completed'),
+            ),
+        )
+    )
+    monkeypatch.setitem(sys.modules, 'openai', openai_mod)
     dotenv_mod = types.ModuleType('dotenv')
     dotenv_mod.load_dotenv = lambda *a, **kw: None
     monkeypatch.setitem(sys.modules, 'dotenv', dotenv_mod)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,6 +3,8 @@ import os
 import asyncio
 from utils.logger import logger
 
+ASSISTANT_ID = None
+
 
 def init_openai_api():
     """Set up the OpenAI API key from environment variables and warn if missing."""
@@ -10,7 +12,15 @@ def init_openai_api():
     if not api_key:
         logger.error("OPENAI_API_KEY не вказано у файлі .env або змінних оточення")
     openai.api_key = api_key
-    return api_key
+
+    global ASSISTANT_ID
+    ASSISTANT_ID = os.getenv("OPENAI_ASSISTANT_ID")
+    return ASSISTANT_ID
+
+
+def get_openai_assistant_id() -> str | None:
+    """Return the assistant ID if set."""
+    return ASSISTANT_ID
 
 
 async def call_openai_chat(
@@ -42,5 +52,72 @@ async def call_openai_chat(
             await asyncio.sleep(1)
 
 
+async def call_openai_assistant(
+    messages: list[dict],
+    assistant_id: str,
+    timeout: int = 15,
+    retries: int = 2,
+) -> str:
+    """Call the OpenAI Assistants API with retries and timeout."""
+    for attempt in range(1, retries + 1):
+        try:
+            thread = await asyncio.wait_for(
+                asyncio.to_thread(openai.beta.threads.create), timeout=timeout
+            )
+            for msg in messages:
+                await asyncio.wait_for(
+                    asyncio.to_thread(
+                        openai.beta.threads.messages.create,
+                        thread_id=thread.id,
+                        role=msg["role"],
+                        content=msg["content"],
+                    ),
+                    timeout=timeout,
+                )
+            run = await asyncio.wait_for(
+                asyncio.to_thread(
+                    openai.beta.threads.runs.create,
+                    thread_id=thread.id,
+                    assistant_id=assistant_id,
+                ),
+                timeout=timeout,
+            )
+            while True:
+                run = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        openai.beta.threads.runs.retrieve,
+                        thread_id=thread.id,
+                        run_id=run.id,
+                    ),
+                    timeout=timeout,
+                )
+                if run.status == "completed":
+                    msgs = await asyncio.wait_for(
+                        asyncio.to_thread(
+                            openai.beta.threads.messages.list,
+                            thread_id=thread.id,
+                        ),
+                        timeout=timeout,
+                    )
+                    return (
+                        msgs.data[0].content[0].text.value.strip()
+                        if msgs.data
+                        else ""
+                    )
+                if run.status in {"failed", "cancelled", "expired"}:
+                    raise openai.OpenAIError(f"run {run.status}")
+                await asyncio.sleep(1)
+        except (openai.OpenAIError, asyncio.TimeoutError) as e:
+            logger.error(f"❌ Помилка OpenAI Assistant (спроба {attempt}): {e}")
+            if attempt == retries:
+                raise
+            await asyncio.sleep(1)
 
-__all__ = ["init_openai_api", "call_openai_chat"]
+
+
+__all__ = [
+    "init_openai_api",
+    "call_openai_chat",
+    "call_openai_assistant",
+    "get_openai_assistant_id",
+]


### PR DESCRIPTION
## Summary
- document `OPENAI_API_KEY` and new `OPENAI_ASSISTANT_ID`
- declare OpenAI dependency
- implement `call_openai_assistant` helper and expose assistant ID
- use assistant in handlers when `OPENAI_ASSISTANT_ID` defined
- extend tests and add test coverage for OpenAI helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68513a37cab88321a178e6106cc16a9f