### PR TITLE
Fix invalid role when using Assistants API

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -65,12 +65,16 @@ async def call_openai_assistant(
                 asyncio.to_thread(openai.beta.threads.create), timeout=timeout
             )
             for msg in messages:
+                role = msg.get("role", "user")
+                if role not in {"user", "assistant"}:
+                    # Assistants API supports only 'user' and 'assistant' roles
+                    role = "user"
                 await asyncio.wait_for(
                     asyncio.to_thread(
                         openai.beta.threads.messages.create,
                         thread_id=thread.id,
-                        role=msg["role"],
-                        content=msg["content"],
+                        role=role,
+                        content=msg.get("content", ""),
                     ),
                     timeout=timeout,
                 )


### PR DESCRIPTION
## Summary
- sanitize role values before sending messages to OpenAI Assistants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68514d1416948321b9b077198a42aabc