### PR TITLE
Fix top-10 YouTube caching and markdown

### DIFF
--- a/handlers/notification_handler.py
+++ b/handlers/notification_handler.py
@@ -55,6 +55,7 @@ async def check_and_notify_new_videos(context: ContextTypes.DEFAULT_TYPE):
             message_ids = []
 
             # Надсилаємо сповіщення користувачам
+            header = escape_markdown("🎥 Нове відео на каналі!", version=2)
             for user_id in bot_users:
                 if (
                     str(user_id) not in video_notifications_disabled
@@ -63,7 +64,7 @@ async def check_and_notify_new_videos(context: ContextTypes.DEFAULT_TYPE):
                     try:
                         message = await context.bot.send_message(
                             chat_id=user_id,
-                            text=f"🎥 Нове відео на каналі!\n\n*{escaped_title}*\n{url}",
+                            text=f"{header}\n\n*{escaped_title}*\n{url}",
                             parse_mode=ParseMode.MARKDOWN_V2,
                         )
                         message_ids.append((str(user_id), message.message_id))
@@ -85,7 +86,7 @@ async def check_and_notify_new_videos(context: ContextTypes.DEFAULT_TYPE):
                     try:
                         message = await context.bot.send_message(
                             chat_id=chat_id,
-                            text=f"🎥 Нове відео на каналі!\n\n*{escaped_title}*\n{url}",
+                            text=f"{header}\n\n*{escaped_title}*\n{url}",
                             parse_mode=ParseMode.MARKDOWN_V2,
                         )
                         message_ids.append((str(chat_id), message.message_id))

--- a/handlers/youtube_menu.py
+++ b/handlers/youtube_menu.py
@@ -10,7 +10,7 @@ from telegram.ext import ContextTypes
 from utils.calendar_utils import (
     get_latest_youtube_video,
     get_most_popular_youtube_video,
-    get_top_10_videos,
+    get_top_10_videos_cached,
 )
 from database import save_bot_message
 from utils.logger import logger
@@ -66,7 +66,7 @@ async def top_10_videos_command(update: Update, context: ContextTypes.DEFAULT_TY
     await auto_add_user(update, context)
     logger.info("Виконання команди: /top_10_videos")
     try:
-        videos = get_top_10_videos()
+        videos = get_top_10_videos_cached()
         if not videos:
             message = await update.message.reply_text(
                 ERROR_VIDEO_NOT_FOUND

--- a/main.py
+++ b/main.py
@@ -82,7 +82,6 @@ from utils.calendar_utils import (
     get_event_details,
     get_latest_youtube_video,
     get_most_popular_youtube_video,
-    get_top_10_videos,  # Оновлюємо
     check_new_videos,
 )
 import json

--- a/utils/calendar_utils.py
+++ b/utils/calendar_utils.py
@@ -649,9 +649,9 @@ def get_most_popular_youtube_video_cached(ttl: int = 300):
 
 
 def get_top_10_videos_cached(ttl: int = 300):
-    from utils.youtube_utils import get_top_5_videos_cached
+    from utils.youtube_utils import get_top_10_videos_cached as yt_top10_cached
 
-    return get_top_5_videos_cached(ttl)
+    return yt_top10_cached(ttl)
 
 # Перевірка нових відео в плейлісті YouTube
 async def check_new_videos():

--- a/utils/youtube_utils.py
+++ b/utils/youtube_utils.py
@@ -114,6 +114,31 @@ def get_top_5_videos(playlist_id):
     return top_5_videos
 
 
+def get_top_10_videos(playlist_id):
+    """Отримує топ-10 відео з плейлиста за кількістю переглядів."""
+    items = get_playlist_items(playlist_id)
+
+    video_stats = []
+
+    for item in items:
+        video_id = item["snippet"]["resourceId"]["videoId"]
+        video_details = get_video_details(video_id)
+
+        if video_details:
+            views = int(video_details["statistics"].get("viewCount", 0))
+            video_stats.append(
+                {
+                    "title": video_details["snippet"]["title"],
+                    "views": views,
+                    "url": f"https://youtu.be/{video_id}",
+                }
+            )
+
+    top_10_videos = sorted(video_stats, key=lambda x: x["views"], reverse=True)[:10]
+
+    return top_10_videos
+
+
 def _get_cached_value(key: str, ttl: int):
     try:
         cached = get_value(key)
@@ -161,6 +186,15 @@ def get_top_5_videos_cached(ttl: int = 300):
     return result
 
 
+def get_top_10_videos_cached(ttl: int = 300):
+    cached = _get_cached_value("yt_top10", ttl)
+    if cached is not None:
+        return cached
+    result = get_top_10_videos(OBERIG_PLAYLIST_ID)
+    _set_cached_value("yt_top10", result)
+    return result
+
+
 __all__ = [
     "get_youtube_service",
     "get_playlist_items",
@@ -168,7 +202,9 @@ __all__ = [
     "get_latest_video",
     "get_most_popular_video",
     "get_top_5_videos",
+    "get_top_10_videos",
     "get_latest_video_cached",
     "get_most_popular_video_cached",
     "get_top_5_videos_cached",
+    "get_top_10_videos_cached",
 ]


### PR DESCRIPTION
## Summary
- escape the header text in video notifications to fix Markdown parsing
- add helper functions for top-10 YouTube videos with caching
- use cached top-10 videos in calendar utilities and menu command
- remove unused import in `main.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68544858e3f88321a108160a728f01da