### PR TITLE
Fix daily reminder duplicate at startup

### DIFF
--- a/handlers/reminder_handler.py
+++ b/handlers/reminder_handler.py
@@ -578,7 +578,7 @@ def schedule_event_reminders(job_queue: JobQueue):
     job_queue.run_repeating(
         send_daily_reminder,
         interval=3600,  # раз на годину
-        first=15,
+        first=3600,
     )
     logger.info("✅ Планування завдань для нагадувань успішно налаштовано.")
 


### PR DESCRIPTION
## Summary
- delay recurring `send_daily_reminder` job to avoid duplicate message when bot starts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a6100ceb88321b87e5ac5a7420b5c