### PR TITLE
Fix daily reminder pluralization

### DIFF
--- a/handlers/reminder_handler.py
+++ b/handlers/reminder_handler.py
@@ -146,8 +146,15 @@ async def send_daily_reminder(context: ContextTypes.DEFAULT_TYPE):
         
         active_chats = get_active_chats()
 
+        def _pluralize_events(n: int) -> str:
+            if n % 10 == 1 and n % 100 != 11:
+                return "подія"
+            if 2 <= n % 10 <= 4 and (n % 100 < 10 or n % 100 >= 20):
+                return "події"
+            return "подій"
+
         header_text = escape_markdown(
-            f"🔔 Розклад подій на сьогодні, {current_date.day:02d} {current_date.strftime('%B').lower()} – {len(events)} подій",
+            f"🔔 Розклад подій на сьогодні, {current_date.day:02d} {current_date.strftime('%B').lower()} – {len(events)} {_pluralize_events(len(events))}",
             version=2,
         )
 
@@ -171,6 +178,7 @@ async def send_daily_reminder(context: ContextTypes.DEFAULT_TYPE):
                 event_time = event.get('start', {}).get('dateTime', event.get('start', {}).get('date', ''))
                 if event_time and 'T' in event_time:
                     event_time = datetime.fromisoformat(event_time.replace('Z', '+00:00')).astimezone(berlin_tz).strftime('%H:%M')
+                    event_time = escape_markdown(event_time, version=2)
                 elif event_time:
                     event_time = escape_markdown("(весь день)", version=2)
                 summary = escape_markdown(event.get('summary', 'Без назви'), version=2)

--- a/tests/test_daily_reminder_all_day.py
+++ b/tests/test_daily_reminder_all_day.py
@@ -107,6 +107,8 @@ def test_all_day_event_parsing(monkeypatch, stub_dependencies):
     asyncio.run(module.send_daily_reminder(context))
 
     assert context.bot.send_message.await_count == 2
+    header_args, header_kwargs = context.bot.send_message.await_args_list[0]
+    assert '1 подія' in header_kwargs['text']
     args, kwargs = context.bot.send_message.await_args_list[1]
     assert '\\(весь день\\)' in kwargs['text']
     assert kwargs['parse_mode'] == tg.constants.ParseMode.MARKDOWN_V2

--- a/tests/test_daily_reminder_multiple.py
+++ b/tests/test_daily_reminder_multiple.py
@@ -100,5 +100,7 @@ def test_send_daily_reminder_sends_multiple(monkeypatch, stub_dependencies):
     asyncio.run(module.send_daily_reminder(context))
 
     assert context.bot.send_message.await_count == 3
+    header_args, header_kwargs = context.bot.send_message.await_args_list[0]
+    assert '2 події' in header_kwargs['text']
     args0, kwargs0 = context.bot.send_message.await_args_list[1]
     assert kwargs0['reply_markup'].inline_keyboard


### PR DESCRIPTION
## Summary
- correct plural form for daily reminder header
- escape event time in daily reminder messages
- update tests for singular and plural cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b93460f1883219b727d29b59625fa