### PR TITLE
Fix birthday greeting hashtag escaping

### DIFF
--- a/handlers/reminder_handler.py
+++ b/handlers/reminder_handler.py
@@ -403,7 +403,7 @@ async def generate_birthday_greeting(name: str, time_of_day: str) -> str:
         if not any(emoji in greeting for emoji in ["🎵", "🎂", "😊", "🎉"]):
             greeting = f"{greeting} 🎵🎂😊"
         if '#Оберіг' not in greeting:
-            greeting += " #Оберіг #ДеньНародження"
+            greeting += r" \#Оберіг \#ДеньНародження"
 
         if len(greeting) > 4096:
             greeting = greeting[:4090] + "..."

--- a/tests/test_birthday_greetings.py
+++ b/tests/test_birthday_greetings.py
@@ -147,7 +147,8 @@ def test_check_birthday_greetings_sends_and_stores(monkeypatch, stub_dependencie
     context.bot.send_message.assert_awaited_once()
     args, kwargs = context.bot.send_message.await_args
     assert kwargs['parse_mode'] == module.ParseMode.MARKDOWN_V2
-    assert '\\' not in kwargs['text']
+    assert '\\#Оберіг' in kwargs['text']
+    assert '\\#ДеньНародження' in kwargs['text']
 
     rows = conn.execute('SELECT * FROM birthday_greetings').fetchall()
     assert len(rows) == 1


### PR DESCRIPTION
## Summary
- escape Markdown V2 hashtags in `generate_birthday_greeting`
- adjust unit test expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b9d8fc94883218f1be1d4bc07d6b7