### PR TITLE
Improve birthday name extraction

### DIFF
--- a/handlers/reminder_handler.py
+++ b/handlers/reminder_handler.py
@@ -396,7 +396,8 @@ def extract_birthday_name(summary: str) -> str:
             candidate = match.group(1)
             parts = re.findall(r"[\w'’\-\u0400-\u04FF]+", candidate)
             if parts:
-                return parts[-1]
+                # take the first token as the name to avoid returning the surname
+                return parts[0]
     except Exception:
         pass
 

--- a/tests/test_birthday_greetings.py
+++ b/tests/test_birthday_greetings.py
@@ -239,6 +239,14 @@ def test_extract_birthday_name(monkeypatch, stub_dependencies):
     assert module.extract_birthday_name(summary) == 'Таміла'
 
 
+def test_extract_birthday_name_with_surname(monkeypatch, stub_dependencies):
+    module = importlib.import_module('handlers.reminder_handler')
+    importlib.reload(module)
+
+    summary = 'Таміла Романченко – день народження'
+    assert module.extract_birthday_name(summary) == 'Таміла'
+
+
 def test_startup_birthday_check_runs_any_time(monkeypatch, stub_dependencies):
     module = importlib.import_module('handlers.reminder_handler')
     importlib.reload(module)


### PR DESCRIPTION
## Summary
- fix `extract_birthday_name` to return the first token when the summary is in the `Name – день народження` format
- test new pattern to ensure we extract the first name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bcdd3b4948321b08ffdc0ca3d3c3d