### PR TITLE
Refactor chat history retrieval in assistant handler

### DIFF
--- a/handlers/oberig_assistant_handler.py
+++ b/handlers/oberig_assistant_handler.py
@@ -54,11 +54,6 @@ async def search_chat_content(
     """
     Шукає повідомлення і файли в історії чату за ключовим словом.
     """
-    повідомлення = []
-    асинхронізація для повідомлення в update.effective_chat.get_history(limit= 50 ):
- 
-        messages.append(повідомлення)
-    # Зменшено до 50 для економії ресурсів
     messages = []
     async for message in update.effective_chat.get_history(limit=50):
         messages.append(message)


### PR DESCRIPTION
## Summary
- fix broken placeholder code in `search_chat_content` with proper async message history loop

## Testing
- `pytest`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'openai' and proxy prevented pip installation)*

------
https://chatgpt.com/codex/tasks/task_e_68adbfb31c9c832189c0dd1868bcc570